### PR TITLE
fix: prevent session data loss during quota recovery

### DIFF
--- a/app.js
+++ b/app.js
@@ -3423,26 +3423,37 @@ const SessionManager = (() => {
         return true;
     } catch (e) {
         if (e.name === 'QuotaExceededError' || e.code === 22 || e.code === 1014) {
-            // Try to recover: evict oldest sessions and retry
-            const recovered = _evictOldest(sessions, 5);
-            try {
-                localStorage.setItem(STORAGE_KEY, JSON.stringify(recovered));
-                return true;
-            } catch {
-                return false;
+            // Incrementally evict oldest sessions one at a time until it fits
+            let remaining = [...sessions];
+            while (remaining.length > 1) {
+                remaining = _evictOldest(remaining, 1);
+                try {
+                    localStorage.setItem(STORAGE_KEY, JSON.stringify(remaining));
+                    console.warn(`[SessionManager] Evicted session to fit quota. ${remaining.length} sessions remain.`);
+                    return true;
+                } catch { /* continue evicting */ }
+            }
+            // Last resort: try saving the single remaining session
+            if (remaining.length === 1) {
+                try {
+                    localStorage.setItem(STORAGE_KEY, JSON.stringify(remaining));
+                    console.warn('[SessionManager] Evicted all but 1 session to fit quota.');
+                    return true;
+                } catch { /* even 1 session won't fit */ }
             }
         }
         return false;
     }
   }
 
-  /** Evict the N oldest sessions (by updatedAt). */
+  /** Evict the N oldest sessions (by updatedAt), always keeping at least 1. */
   function _evictOldest(sessions, count) {
-    if (sessions.length <= count) return [];
+    if (sessions.length <= 1) return sessions;
+    const toEvict = Math.min(count, sessions.length - 1);
     const sorted = [...sessions].sort((a, b) =>
         new Date(a.updatedAt).getTime() - new Date(b.updatedAt).getTime()
     );
-    return sorted.slice(count);
+    return sorted.slice(toEvict);
   }
 
   /** Enforce maximum session count, evicting oldest when exceeded. */


### PR DESCRIPTION
## Fix

Fixes #28 — SessionManager._saveAll quota recovery could silently wipe all sessions.

### Changes
- **\_evictOldest\**: Now always keeps at least 1 session (returns \sessions\ unchanged when \length <= 1\ instead of returning \[]\)
- **\_saveAll\**: Evicts incrementally (1 session at a time) instead of bulk-evicting 5, minimizing data loss while still recovering from quota errors

### Before
Users with ≤5 sessions would lose ALL sessions silently on quota error.

### After
At most N-1 sessions evicted, always keeping the most recent one. Incremental eviction means only the minimum necessary sessions are removed.