### PR TITLE
feat: add SmartRetry — auto-retry with exponential backoff for API failures

### DIFF
--- a/app.js
+++ b/app.js
@@ -53,6 +53,7 @@
  *   PromptLibrary        — user-created prompt snippets with folders, search, usage tracking, import/export
  *   MessageTranslator    — inline message translation to 20+ languages via OpenAI API
  *   MessageEditor        — edit & resend user messages (truncate + reload into input)
+ *   SmartRetry           — automatic retry with exponential backoff for transient API failures
  *
  * All modules communicate through a thin public API; no direct DOM
  * manipulation outside UIController except where unavoidable (sandbox).
@@ -8481,6 +8482,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Scheduled messages
   MessageScheduler.init();
+  SmartRetry.init();
 });
 
 
@@ -15464,5 +15466,285 @@ const MessageScheduler = (() => {
     clearHistory,
     togglePanel,
     onSend
+  };
+})();
+
+/* ---------- Smart Retry ---------- */
+/**
+ * SmartRetry — Automatic retry with exponential backoff for transient API failures.
+ *
+ * Intercepts 429 (rate limit), 500, 502, 503, and network errors. Shows a
+ * visual countdown indicator in the chat output area with a cancel button.
+ * Retries up to {@link MAX_RETRIES} times with exponential delays (1s, 2s, 4s).
+ *
+ * Usage:
+ *   const result = await SmartRetry.withRetry(() => callOpenAI(key, msgs));
+ *   // result is the first successful response, or the final failure after all retries
+ *
+ * The retry indicator shows: attempt number, countdown timer, and a cancel button.
+ * Cancelled retries return the original error immediately.
+ *
+ * @namespace SmartRetry
+ */
+const SmartRetry = (() => {
+  const STORAGE_KEY = 'agenticchat_smart_retry';
+  const MAX_RETRIES = 3;
+  const BASE_DELAY_MS = 1000;
+  const RETRYABLE_STATUSES = new Set([429, 500, 502, 503]);
+
+  let _enabled = true;
+  let _cancelled = false;
+  let _retryStats = { totalRetries: 0, successfulRetries: 0, failedRetries: 0 };
+  let _countdownInterval = null;
+
+  /** Load persisted settings. */
+  function _loadSettings() {
+    const raw = SafeStorage.get(STORAGE_KEY);
+    if (raw) {
+      try {
+        const data = JSON.parse(raw);
+        _enabled = data.enabled !== false;
+        if (data.stats) _retryStats = data.stats;
+      } catch (_) {}
+    }
+  }
+
+  /** Save settings to localStorage. */
+  function _save() {
+    SafeStorage.set(STORAGE_KEY, JSON.stringify({
+      enabled: _enabled,
+      stats: _retryStats
+    }));
+  }
+
+  /** Check if a result should be retried. */
+  function isRetryable(result) {
+    if (!result) return false;
+    if (result.networkError) return true;
+    return !!(result.status && RETRYABLE_STATUSES.has(result.status));
+  }
+
+  /** Calculate delay for attempt n (0-indexed): base * 2^n + jitter. */
+  function getDelay(attempt) {
+    const base = BASE_DELAY_MS * Math.pow(2, attempt);
+    const jitter = Math.floor(Math.random() * 300);
+    return base + jitter;
+  }
+
+  /** Show retry indicator in chat output. */
+  function _showRetryIndicator(attempt, delayMs, error) {
+    const container = document.getElementById('chat-output');
+    if (!container) return;
+
+    let remaining = Math.ceil(delayMs / 1000);
+    const retryDiv = document.createElement('div');
+    retryDiv.className = 'smart-retry-indicator';
+    retryDiv.id = 'smart-retry-indicator';
+
+    const statusText = error || 'Request failed';
+    retryDiv.innerHTML =
+      '<div class="retry-header">' +
+        '<span class="retry-icon">\u27F3</span> ' +
+        '<strong>Retrying</strong> (attempt ' + (attempt + 1) + '/' + MAX_RETRIES + ')' +
+      '</div>' +
+      '<div class="retry-reason">' + _escapeHtml(statusText) + '</div>' +
+      '<div class="retry-countdown">Retrying in <span id="retry-seconds">' + remaining + '</span>s\u2026</div>' +
+      '<button class="retry-cancel-btn" id="retry-cancel-btn">Cancel</button>';
+
+    const existing = document.getElementById('smart-retry-indicator');
+    if (existing) existing.remove();
+
+    container.appendChild(retryDiv);
+
+    const cancelBtn = document.getElementById('retry-cancel-btn');
+    if (cancelBtn) {
+      cancelBtn.addEventListener('click', () => {
+        _cancelled = true;
+        _clearIndicator();
+      });
+    }
+
+    if (_countdownInterval) clearInterval(_countdownInterval);
+    _countdownInterval = setInterval(() => {
+      remaining--;
+      const el = document.getElementById('retry-seconds');
+      if (el) el.textContent = String(remaining);
+      if (remaining <= 0) {
+        clearInterval(_countdownInterval);
+        _countdownInterval = null;
+      }
+    }, 1000);
+  }
+
+  /** Remove retry indicator. */
+  function _clearIndicator() {
+    if (_countdownInterval) {
+      clearInterval(_countdownInterval);
+      _countdownInterval = null;
+    }
+    const el = document.getElementById('smart-retry-indicator');
+    if (el) el.remove();
+  }
+
+  /** Escape HTML for safe display. */
+  function _escapeHtml(str) {
+    const div = document.createElement('div');
+    div.textContent = str;
+    return div.innerHTML;
+  }
+
+  /**
+   * Wrap an async API call with automatic retry logic.
+   *
+   * @param {Function} fn — Async function returning {ok, status?, error?, networkError?}
+   * @param {Object} [opts] — Options
+   * @param {number} [opts.maxRetries] — Override max retries (default 3)
+   * @param {boolean} [opts.showIndicator] — Show visual retry indicator (default true)
+   * @returns {Promise<Object>} The API result (success or final failure)
+   */
+  async function withRetry(fn, opts) {
+    if (!_enabled) return fn();
+
+    const maxRetries = (opts && opts.maxRetries) || MAX_RETRIES;
+    const showIndicator = !(opts && opts.showIndicator === false);
+    _cancelled = false;
+
+    let lastResult = null;
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        const result = await fn();
+
+        if (result && result.ok) {
+          if (attempt > 0) {
+            _retryStats.successfulRetries++;
+            _save();
+            _clearIndicator();
+          }
+          return result;
+        }
+
+        lastResult = result;
+
+        if (attempt < maxRetries && isRetryable(result)) {
+          _retryStats.totalRetries++;
+          const delay = getDelay(attempt);
+
+          if (showIndicator) {
+            _showRetryIndicator(attempt, delay, result.error);
+          }
+
+          await new Promise((resolve) => {
+            const timer = setTimeout(resolve, delay);
+            const checkCancel = setInterval(() => {
+              if (_cancelled) {
+                clearTimeout(timer);
+                clearInterval(checkCancel);
+                resolve();
+              }
+            }, 100);
+            setTimeout(() => clearInterval(checkCancel), delay + 100);
+          });
+
+          if (_cancelled) {
+            _clearIndicator();
+            _retryStats.failedRetries++;
+            _save();
+            return lastResult;
+          }
+
+          _clearIndicator();
+          continue;
+        }
+
+        if (attempt > 0) {
+          _retryStats.failedRetries++;
+          _save();
+        }
+        return result;
+
+      } catch (err) {
+        lastResult = {
+          ok: false,
+          error: 'Network error: ' + err.message,
+          networkError: true
+        };
+
+        if (attempt < maxRetries) {
+          _retryStats.totalRetries++;
+          const delay = getDelay(attempt);
+
+          if (showIndicator) {
+            _showRetryIndicator(attempt, delay, lastResult.error);
+          }
+
+          await new Promise((resolve) => {
+            const timer = setTimeout(resolve, delay);
+            const checkCancel = setInterval(() => {
+              if (_cancelled) {
+                clearTimeout(timer);
+                clearInterval(checkCancel);
+                resolve();
+              }
+            }, 100);
+            setTimeout(() => clearInterval(checkCancel), delay + 100);
+          });
+
+          if (_cancelled) {
+            _clearIndicator();
+            _retryStats.failedRetries++;
+            _save();
+            return lastResult;
+          }
+
+          _clearIndicator();
+          continue;
+        }
+
+        _retryStats.failedRetries++;
+        _save();
+        return lastResult;
+      }
+    }
+
+    return lastResult;
+  }
+
+  /** Toggle retry on/off. */
+  function setEnabled(val) {
+    _enabled = !!val;
+    _save();
+  }
+
+  function isEnabled() { return _enabled; }
+
+  function getStats() { return Object.assign({}, _retryStats); }
+
+  function resetStats() {
+    _retryStats = { totalRetries: 0, successfulRetries: 0, failedRetries: 0 };
+    _save();
+  }
+
+  function cancel() {
+    _cancelled = true;
+    _clearIndicator();
+  }
+
+  function init() { _loadSettings(); }
+
+  return {
+    withRetry,
+    isRetryable,
+    getDelay,
+    setEnabled,
+    isEnabled,
+    getStats,
+    resetStats,
+    cancel,
+    init,
+    MAX_RETRIES,
+    RETRYABLE_STATUSES,
+    _showRetryIndicator,
+    _clearIndicator
   };
 })();

--- a/style.css
+++ b/style.css
@@ -2572,3 +2572,59 @@ html.light .fork-notification {
   .scheduler-panel { width: 100%; right: -100%; }
   .scheduler-time-row { flex-direction: column; align-items: stretch; }
 }
+
+/* ---------- Smart Retry ---------- */
+.smart-retry-indicator {
+  margin: 12px 0;
+  padding: 12px 16px;
+  border-radius: 8px;
+  background: #1a1a2e;
+  border: 1px solid #e94560;
+  animation: retryPulse 2s ease-in-out infinite;
+}
+.retry-header {
+  font-size: 14px;
+  color: #e94560;
+  margin-bottom: 6px;
+}
+.retry-icon {
+  display: inline-block;
+  animation: retrySpin 1s linear infinite;
+}
+.retry-reason {
+  font-size: 12px;
+  color: #888;
+  margin-bottom: 8px;
+  word-break: break-word;
+}
+.retry-countdown {
+  font-size: 13px;
+  color: #ccc;
+  margin-bottom: 8px;
+}
+#retry-seconds {
+  font-weight: bold;
+  color: #e94560;
+}
+.retry-cancel-btn {
+  background: transparent;
+  border: 1px solid #e94560;
+  color: #e94560;
+  padding: 4px 14px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+  transition: background 0.2s;
+}
+.retry-cancel-btn:hover {
+  background: #e94560;
+  color: #fff;
+}
+@keyframes retrySpin {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+@keyframes retryPulse {
+  0%, 100% { border-color: #e94560; }
+  50%      { border-color: #e9456080; }
+}

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -246,6 +246,7 @@ function loadApp() {
   // Replace `const` with `globalThis.X =` for the top-level module declarations
   // so they become accessible in test scope.
   const modules = [
+    'SafeStorage',
     'ChatConfig',
     'ConversationManager',
     'SandboxRunner',
@@ -293,7 +294,9 @@ function loadApp() {
     'PromptLibrary',
     'ModelCompare',
     'MessageTranslator',
-    'MessageEditor'
+    'MessageEditor',
+    'MessageScheduler',
+    'SmartRetry'
   ];
 
   for (const mod of modules) {

--- a/tests/smart-retry.test.js
+++ b/tests/smart-retry.test.js
@@ -1,0 +1,286 @@
+/**
+ * SmartRetry - Unit Tests
+ */
+
+const { setupDOM, loadApp } = require('./setup');
+
+beforeEach(() => {
+  setupDOM();
+  loadApp();
+  SmartRetry.init();
+  SmartRetry.setEnabled(true);
+  SmartRetry.resetStats();
+});
+
+/* ================================================================
+ * Core retry logic
+ * ================================================================ */
+describe('SmartRetry', () => {
+
+  test('returns successful result immediately without retry', async () => {
+    const fn = jest.fn().mockResolvedValue({ ok: true, data: 'good' });
+    const result = await SmartRetry.withRetry(fn, { showIndicator: false });
+    expect(result.ok).toBe(true);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test('retries on 429 status', async () => {
+    const fn = jest.fn()
+      .mockResolvedValueOnce({ ok: false, status: 429, error: 'rate limited' })
+      .mockResolvedValue({ ok: true, data: 'good' });
+    const result = await SmartRetry.withRetry(fn, { showIndicator: false, maxRetries: 1 });
+    expect(result.ok).toBe(true);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  test('retries on 500 status', async () => {
+    const fn = jest.fn()
+      .mockResolvedValueOnce({ ok: false, status: 500, error: 'server error' })
+      .mockResolvedValue({ ok: true, data: 'recovered' });
+    const result = await SmartRetry.withRetry(fn, { showIndicator: false, maxRetries: 1 });
+    expect(result.ok).toBe(true);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  test('retries on 502 status', async () => {
+    const fn = jest.fn()
+      .mockResolvedValueOnce({ ok: false, status: 502, error: 'bad gateway' })
+      .mockResolvedValue({ ok: true, data: 'ok' });
+    const result = await SmartRetry.withRetry(fn, { showIndicator: false, maxRetries: 1 });
+    expect(result.ok).toBe(true);
+  });
+
+  test('retries on 503 status', async () => {
+    const fn = jest.fn()
+      .mockResolvedValueOnce({ ok: false, status: 503, error: 'unavailable' })
+      .mockResolvedValue({ ok: true, data: 'ok' });
+    const result = await SmartRetry.withRetry(fn, { showIndicator: false, maxRetries: 1 });
+    expect(result.ok).toBe(true);
+  });
+
+  test('retries on network error (thrown exception)', async () => {
+    const fn = jest.fn()
+      .mockRejectedValueOnce(new Error('fetch failed'))
+      .mockResolvedValue({ ok: true, data: 'recovered' });
+    const result = await SmartRetry.withRetry(fn, { showIndicator: false, maxRetries: 1 });
+    expect(result.ok).toBe(true);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  test('does NOT retry on 401 (not transient)', async () => {
+    const fn = jest.fn()
+      .mockResolvedValue({ ok: false, status: 401, error: 'unauthorized' });
+    const result = await SmartRetry.withRetry(fn, { showIndicator: false });
+    expect(result.ok).toBe(false);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test('does NOT retry on 400 (not transient)', async () => {
+    const fn = jest.fn()
+      .mockResolvedValue({ ok: false, status: 400, error: 'bad request' });
+    const result = await SmartRetry.withRetry(fn, { showIndicator: false });
+    expect(result.ok).toBe(false);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test('gives up after maxRetries', async () => {
+    const fn = jest.fn()
+      .mockResolvedValue({ ok: false, status: 429, error: 'rate limited' });
+    const result = await SmartRetry.withRetry(fn, { showIndicator: false, maxRetries: 2 });
+    expect(result.ok).toBe(false);
+    expect(fn).toHaveBeenCalledTimes(3); // initial + 2 retries
+  });
+
+  test('skips retry when disabled', async () => {
+    SmartRetry.setEnabled(false);
+    const fn = jest.fn()
+      .mockResolvedValue({ ok: false, status: 429, error: 'rate limited' });
+    const result = await SmartRetry.withRetry(fn, { showIndicator: false });
+    expect(result.ok).toBe(false);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+
+/* ================================================================
+ * isRetryable
+ * ================================================================ */
+describe('SmartRetry.isRetryable', () => {
+  test('returns true for 429', () => {
+    expect(SmartRetry.isRetryable({ status: 429 })).toBe(true);
+  });
+
+  test('returns true for 500', () => {
+    expect(SmartRetry.isRetryable({ status: 500 })).toBe(true);
+  });
+
+  test('returns true for 502', () => {
+    expect(SmartRetry.isRetryable({ status: 502 })).toBe(true);
+  });
+
+  test('returns true for 503', () => {
+    expect(SmartRetry.isRetryable({ status: 503 })).toBe(true);
+  });
+
+  test('returns true for networkError', () => {
+    expect(SmartRetry.isRetryable({ networkError: true })).toBe(true);
+  });
+
+  test('returns false for 401', () => {
+    expect(SmartRetry.isRetryable({ status: 401 })).toBe(false);
+  });
+
+  test('returns false for 400', () => {
+    expect(SmartRetry.isRetryable({ status: 400 })).toBe(false);
+  });
+
+  test('returns false for null', () => {
+    expect(SmartRetry.isRetryable(null)).toBe(false);
+  });
+
+  test('returns false for successful result', () => {
+    expect(SmartRetry.isRetryable({ ok: true })).toBe(false);
+  });
+});
+
+/* ================================================================
+ * getDelay (exponential backoff)
+ * ================================================================ */
+describe('SmartRetry.getDelay', () => {
+  test('attempt 0 is ~1000ms', () => {
+    const d = SmartRetry.getDelay(0);
+    expect(d).toBeGreaterThanOrEqual(1000);
+    expect(d).toBeLessThan(1400);
+  });
+
+  test('attempt 1 is ~2000ms', () => {
+    const d = SmartRetry.getDelay(1);
+    expect(d).toBeGreaterThanOrEqual(2000);
+    expect(d).toBeLessThan(2400);
+  });
+
+  test('attempt 2 is ~4000ms', () => {
+    const d = SmartRetry.getDelay(2);
+    expect(d).toBeGreaterThanOrEqual(4000);
+    expect(d).toBeLessThan(4400);
+  });
+
+  test('delays increase exponentially', () => {
+    const d0 = SmartRetry.getDelay(0);
+    const d1 = SmartRetry.getDelay(1);
+    const d2 = SmartRetry.getDelay(2);
+    expect(d1).toBeGreaterThan(d0);
+    expect(d2).toBeGreaterThan(d1);
+  });
+});
+
+/* ================================================================
+ * Statistics
+ * ================================================================ */
+describe('SmartRetry statistics', () => {
+  test('starts with zero stats', () => {
+    const stats = SmartRetry.getStats();
+    expect(stats.totalRetries).toBe(0);
+    expect(stats.successfulRetries).toBe(0);
+    expect(stats.failedRetries).toBe(0);
+  });
+
+  test('tracks successful retry', async () => {
+    const fn = jest.fn()
+      .mockResolvedValueOnce({ ok: false, status: 429, error: 'rl' })
+      .mockResolvedValue({ ok: true, data: 'ok' });
+    await SmartRetry.withRetry(fn, { showIndicator: false, maxRetries: 1 });
+    const stats = SmartRetry.getStats();
+    expect(stats.totalRetries).toBe(1);
+    expect(stats.successfulRetries).toBe(1);
+  });
+
+  test('tracks failed retry (exhausted)', async () => {
+    const fn = jest.fn()
+      .mockResolvedValue({ ok: false, status: 500, error: 'err' });
+    await SmartRetry.withRetry(fn, { showIndicator: false, maxRetries: 1 });
+    const stats = SmartRetry.getStats();
+    expect(stats.totalRetries).toBe(1);
+    expect(stats.failedRetries).toBe(1);
+  });
+
+  test('resetStats clears all counters', async () => {
+    const fn = jest.fn()
+      .mockResolvedValueOnce({ ok: false, status: 429, error: 'rl' })
+      .mockResolvedValue({ ok: true, data: 'ok' });
+    await SmartRetry.withRetry(fn, { showIndicator: false, maxRetries: 1 });
+    SmartRetry.resetStats();
+    const stats = SmartRetry.getStats();
+    expect(stats.totalRetries).toBe(0);
+    expect(stats.successfulRetries).toBe(0);
+    expect(stats.failedRetries).toBe(0);
+  });
+});
+
+/* ================================================================
+ * Enable/Disable
+ * ================================================================ */
+describe('SmartRetry enable/disable', () => {
+  test('isEnabled defaults to true', () => {
+    expect(SmartRetry.isEnabled()).toBe(true);
+  });
+
+  test('setEnabled(false) disables retry', () => {
+    SmartRetry.setEnabled(false);
+    expect(SmartRetry.isEnabled()).toBe(false);
+  });
+
+  test('setEnabled(true) re-enables retry', () => {
+    SmartRetry.setEnabled(false);
+    SmartRetry.setEnabled(true);
+    expect(SmartRetry.isEnabled()).toBe(true);
+  });
+});
+
+/* ================================================================
+ * Retry indicator DOM
+ * ================================================================ */
+describe('SmartRetry indicator', () => {
+  test('_showRetryIndicator creates DOM element', () => {
+    SmartRetry._showRetryIndicator(0, 2000, 'test error');
+    const el = document.getElementById('smart-retry-indicator');
+    expect(el).not.toBeNull();
+    expect(el.textContent).toContain('Retrying');
+    expect(el.textContent).toContain('test error');
+  });
+
+  test('_clearIndicator removes DOM element', () => {
+    SmartRetry._showRetryIndicator(0, 2000, 'test');
+    SmartRetry._clearIndicator();
+    const el = document.getElementById('smart-retry-indicator');
+    expect(el).toBeNull();
+  });
+
+  test('showing new indicator replaces old one', () => {
+    SmartRetry._showRetryIndicator(0, 1000, 'first');
+    SmartRetry._showRetryIndicator(1, 2000, 'second');
+    const els = document.querySelectorAll('#smart-retry-indicator');
+    expect(els.length).toBe(1);
+    expect(els[0].textContent).toContain('second');
+  });
+});
+
+/* ================================================================
+ * Constants
+ * ================================================================ */
+describe('SmartRetry constants', () => {
+  test('MAX_RETRIES is 3', () => {
+    expect(SmartRetry.MAX_RETRIES).toBe(3);
+  });
+
+  test('RETRYABLE_STATUSES includes 429, 500, 502, 503', () => {
+    expect(SmartRetry.RETRYABLE_STATUSES.has(429)).toBe(true);
+    expect(SmartRetry.RETRYABLE_STATUSES.has(500)).toBe(true);
+    expect(SmartRetry.RETRYABLE_STATUSES.has(502)).toBe(true);
+    expect(SmartRetry.RETRYABLE_STATUSES.has(503)).toBe(true);
+  });
+
+  test('RETRYABLE_STATUSES does NOT include 401 or 404', () => {
+    expect(SmartRetry.RETRYABLE_STATUSES.has(401)).toBe(false);
+    expect(SmartRetry.RETRYABLE_STATUSES.has(404)).toBe(false);
+  });
+});


### PR DESCRIPTION
Adds automatic retry with exponential backoff for transient API failures (429, 500, 502, 503, network errors).

## Features

- **Exponential backoff**: 1s → 2s → 4s base delays with random jitter to avoid thundering herd
- **Visual retry indicator**: Shows attempt count, countdown timer, error reason, and cancel button
- **Cancellation**: User can cancel mid-retry via the indicator button or `SmartRetry.cancel()`
- **Statistics**: Tracks total retries, successful retries, and failed retries (persisted via SafeStorage)
- **Toggle**: Enable/disable retry globally via `SmartRetry.setEnabled(bool)`
- **Smart filtering**: Only retries transient errors; permanent errors (401, 400, 404) fail immediately

## Usage

```js
const result = await SmartRetry.withRetry(() => callOpenAI(key, messages));
```

## CSS

New classes: `.smart-retry-indicator`, `.retry-header`, `.retry-icon` (spinning), `.retry-reason`, `.retry-countdown`, `.retry-cancel-btn`. Pulsing border animation on the indicator.

## Tests

36 test cases covering:
- Core retry logic (429, 500, 502, 503, network errors)
- Non-retryable status codes (401, 400)
- Max retry exhaustion
- Enable/disable toggle
- Exponential delay calculation
- Statistics tracking and reset
- DOM indicator creation/removal
- Constants verification
