### PR TITLE
feat: UsageHeatmap — GitHub-style 7x24 activity heatmap (32 tests)

### DIFF
--- a/app.js
+++ b/app.js
@@ -54,6 +54,7 @@
  *   MessageTranslator    — inline message translation to 20+ languages via OpenAI API
  *   MessageEditor        — edit & resend user messages (truncate + reload into input)
  *   SmartRetry           — automatic retry with exponential backoff for transient API failures
+ *   UsageHeatmap         — GitHub-style 7×24 activity heatmap across all sessions
  *
  * All modules communicate through a thin public API; no direct DOM
  * manipulation outside UIController except where unavoidable (sandbox).
@@ -8298,6 +8299,7 @@ document.addEventListener('DOMContentLoaded', () => {
       ModelSelector.close();
       Scratchpad.close();
       ConversationChapters.closePanel();
+      UsageHeatmap.close();
     }
   });
 
@@ -8431,6 +8433,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Cost dashboard
   document.getElementById('cost-btn').addEventListener('click', CostDashboard.toggle);
+
+  // Usage heatmap
+  document.getElementById('heatmap-btn').addEventListener('click', UsageHeatmap.toggle);
 
   // Focus / Zen mode
   document.getElementById('zen-btn').addEventListener('click', FocusMode.toggle);
@@ -15748,3 +15753,286 @@ const SmartRetry = (() => {
     _clearIndicator
   };
 })();
+
+/* ---------- Usage Heatmap ---------- */
+/**
+ * GitHub-style 7x24 activity heatmap showing chat patterns across
+ * all saved sessions.  Scans message timestamps and renders a
+ * day-of-week x hour-of-day grid with color intensity proportional
+ * to message count.
+ *
+ * Public API:
+ *   toggle()           - open / close heatmap panel
+ *   open()             - render and show
+ *   close()            - hide panel
+ *   getData()          - raw 7x24 matrix of counts
+ *   getTotalMessages() - total messages scanned
+ *   getPeakHour()      - {day, hour, count} of busiest slot
+ *   getActiveHours()   - number of day x hour slots with >= 1 message
+ *   exportCSV()        - download heatmap data as CSV
+ *
+ * @namespace UsageHeatmap
+ */
+const UsageHeatmap = (() => {
+  const DAY_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+  const FULL_DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday',
+    'Thursday', 'Friday', 'Saturday'];
+
+  let isOpen = false;
+
+  /* -- Data collection ------------------------------------------------- */
+
+  /**
+   * Scan all saved sessions and the current conversation to build
+   * a 7x24 matrix of message counts.
+   * @returns {{grid: number[][], total: number, sessionCount: number}}
+   */
+  function _collectData() {
+    const grid = Array.from({ length: 7 }, () => Array(24).fill(0));
+    let total = 0;
+    let sessionCount = 0;
+
+    if (typeof SessionManager !== 'undefined' && SessionManager.getAll) {
+      const sessions = SessionManager.getAll();
+      sessionCount = sessions.length;
+      for (const session of sessions) {
+        const msgs = session.messages || session.history || [];
+        for (const msg of msgs) {
+          const ts = msg.timestamp || msg.createdAt || msg.time;
+          if (!ts) continue;
+          const d = new Date(ts);
+          if (isNaN(d.getTime())) continue;
+          grid[d.getDay()][d.getHours()]++;
+          total++;
+        }
+      }
+    }
+
+    if (typeof ConversationManager !== 'undefined' && ConversationManager.getHistory) {
+      const current = ConversationManager.getHistory();
+      for (const msg of current) {
+        const ts = msg.timestamp || msg.createdAt || msg.time;
+        if (!ts) continue;
+        const d = new Date(ts);
+        if (isNaN(d.getTime())) continue;
+        grid[d.getDay()][d.getHours()]++;
+        total++;
+      }
+    }
+
+    return { grid, total, sessionCount };
+  }
+
+  function getData() {
+    return _collectData().grid;
+  }
+
+  function getTotalMessages() {
+    return _collectData().total;
+  }
+
+  /**
+   * Find the peak (busiest) day x hour slot.
+   * @returns {{day: number, dayName: string, hour: number, count: number}|null}
+   */
+  function getPeakHour() {
+    const { grid } = _collectData();
+    let maxCount = 0;
+    let peakDay = 0;
+    let peakHour = 0;
+    for (let d = 0; d < 7; d++) {
+      for (let h = 0; h < 24; h++) {
+        if (grid[d][h] > maxCount) {
+          maxCount = grid[d][h];
+          peakDay = d;
+          peakHour = h;
+        }
+      }
+    }
+    if (maxCount === 0) return null;
+    return {
+      day: peakDay,
+      dayName: FULL_DAY_NAMES[peakDay],
+      hour: peakHour,
+      count: maxCount
+    };
+  }
+
+  function getActiveHours() {
+    const { grid } = _collectData();
+    let count = 0;
+    for (let d = 0; d < 7; d++) {
+      for (let h = 0; h < 24; h++) {
+        if (grid[d][h] > 0) count++;
+      }
+    }
+    return count;
+  }
+
+  /* -- Color mapping --------------------------------------------------- */
+
+  function _intensityClass(count, maxCount) {
+    if (count === 0) return 'heatmap-level-0';
+    if (maxCount === 0) return 'heatmap-level-0';
+    const ratio = count / maxCount;
+    if (ratio <= 0.25) return 'heatmap-level-1';
+    if (ratio <= 0.50) return 'heatmap-level-2';
+    if (ratio <= 0.75) return 'heatmap-level-3';
+    return 'heatmap-level-4';
+  }
+
+  function _fmtHour(h) {
+    if (h === 0) return '12a';
+    if (h < 12) return h + 'a';
+    if (h === 12) return '12p';
+    return (h - 12) + 'p';
+  }
+
+  /* -- Rendering ------------------------------------------------------- */
+
+  function _render() {
+    const container = document.getElementById('heatmap-grid');
+    const statsEl = document.getElementById('heatmap-stats');
+    if (!container) return;
+
+    const { grid, total, sessionCount } = _collectData();
+
+    let maxCount = 0;
+    for (let d = 0; d < 7; d++) {
+      for (let h = 0; h < 24; h++) {
+        if (grid[d][h] > maxCount) maxCount = grid[d][h];
+      }
+    }
+
+    let html = '<div class="heatmap-row heatmap-header-row">';
+    html += '<div class="heatmap-label"></div>';
+    for (let h = 0; h < 24; h++) {
+      const show = h % 3 === 0;
+      html += '<div class="heatmap-hour-label">' + (show ? _fmtHour(h) : '') + '</div>';
+    }
+    html += '</div>';
+
+    for (let d = 0; d < 7; d++) {
+      html += '<div class="heatmap-row">';
+      html += '<div class="heatmap-label">' + DAY_NAMES[d] + '</div>';
+      for (let h = 0; h < 24; h++) {
+        const count = grid[d][h];
+        const cls = _intensityClass(count, maxCount);
+        const tip = FULL_DAY_NAMES[d] + ' ' + _fmtHour(h) + ': ' + count +
+          ' message' + (count !== 1 ? 's' : '');
+        html += '<div class="heatmap-cell ' + cls +
+          '" title="' + tip + '" data-count="' + count + '"></div>';
+      }
+      html += '</div>';
+    }
+
+    html += '<div class="heatmap-legend">';
+    html += '<span class="heatmap-legend-label">Less</span>';
+    for (let i = 0; i <= 4; i++) {
+      html += '<div class="heatmap-cell heatmap-legend-cell heatmap-level-' + i + '"></div>';
+    }
+    html += '<span class="heatmap-legend-label">More</span>';
+    html += '</div>';
+
+    container.innerHTML = html;
+
+    if (statsEl) {
+      const peak = getPeakHour();
+      const active = getActiveHours();
+      let s = '<div class="heatmap-stat">';
+      s += '<span class="heatmap-stat-value">' + total.toLocaleString() + '</span>';
+      s += '<span class="heatmap-stat-label">messages</span></div>';
+      s += '<div class="heatmap-stat">';
+      s += '<span class="heatmap-stat-value">' + sessionCount + '</span>';
+      s += '<span class="heatmap-stat-label">sessions scanned</span></div>';
+      s += '<div class="heatmap-stat">';
+      s += '<span class="heatmap-stat-value">' + active + '/168</span>';
+      s += '<span class="heatmap-stat-label">active hours</span></div>';
+      if (peak) {
+        s += '<div class="heatmap-stat">';
+        s += '<span class="heatmap-stat-value">' + peak.dayName + ' ' +
+          _fmtHour(peak.hour) + '</span>';
+        s += '<span class="heatmap-stat-label">peak (' + peak.count + ' msgs)</span></div>';
+      }
+      statsEl.innerHTML = s;
+    }
+  }
+
+  /* -- Panel management ------------------------------------------------ */
+
+  function open() {
+    const panel = document.getElementById('heatmap-panel');
+    const overlay = document.getElementById('heatmap-overlay');
+    if (panel) panel.style.display = '';
+    if (overlay) overlay.style.display = '';
+    isOpen = true;
+    _render();
+  }
+
+  function close() {
+    const panel = document.getElementById('heatmap-panel');
+    const overlay = document.getElementById('heatmap-overlay');
+    if (panel) panel.style.display = 'none';
+    if (overlay) overlay.style.display = 'none';
+    isOpen = false;
+  }
+
+  function toggle() {
+    isOpen ? close() : open();
+  }
+
+  /* -- CSV export ------------------------------------------------------ */
+
+  function exportCSV() {
+    const { grid } = _collectData();
+    let csv = 'Day,' +
+      Array.from({ length: 24 }, (_, h) => _fmtHour(h)).join(',') + '\n';
+    for (let d = 0; d < 7; d++) {
+      csv += DAY_NAMES[d] + ',' + grid[d].join(',') + '\n';
+    }
+
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'usage-heatmap.csv';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }
+
+  /* -- Init ------------------------------------------------------------ */
+
+  function init() {
+    const closeBtn = document.getElementById('heatmap-close-btn');
+    if (closeBtn) closeBtn.addEventListener('click', close);
+
+    const overlay = document.getElementById('heatmap-overlay');
+    if (overlay) overlay.addEventListener('click', close);
+
+    const exportBtn = document.getElementById('heatmap-export-btn');
+    if (exportBtn) exportBtn.addEventListener('click', exportCSV);
+
+    const refreshBtn = document.getElementById('heatmap-refresh-btn');
+    if (refreshBtn) refreshBtn.addEventListener('click', _render);
+  }
+
+  return {
+    toggle,
+    open,
+    close,
+    getData,
+    getTotalMessages,
+    getPeakHour,
+    getActiveHours,
+    exportCSV,
+    init,
+    _collectData,
+    _intensityClass,
+    _fmtHour,
+    _render
+  };
+})();
+
+document.addEventListener('DOMContentLoaded', UsageHeatmap.init);

--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
     <button id="shortcuts-btn" class="btn-secondary" title="Keyboard shortcuts (press ? for help)">⌨️</button>
     <button id="stats-btn" class="btn-secondary" title="Chat statistics (Ctrl+I)">📊</button>
     <button id="cost-btn" class="btn-secondary" title="Cost dashboard — track API spending">💰</button>
+    <button id="heatmap-btn" class="btn-secondary" title="Usage heatmap — activity patterns">🗓️</button>
     <button id="voice-btn" class="btn-secondary" title="Voice input — speak your prompt (Ctrl+M)" aria-label="Toggle voice input">🎤</button>
     <button id="persona-btn" class="btn-secondary" title="System prompt presets (Ctrl+P)">🎭</button>
     <button id="model-btn" class="btn-secondary" title="Select AI model">🤖 <span id="model-label">GPT-4o</span></button>
@@ -368,6 +369,21 @@
         <button id="prompt-library-confirm-btn">Save</button>
       </div>
     </div>
+  </div>
+
+  <!-- Usage Heatmap Panel -->
+  <div id="heatmap-overlay"></div>
+  <div id="heatmap-panel" aria-label="Usage heatmap" style="display:none;">
+    <div id="heatmap-header">
+      <span>🗓️ Usage Heatmap</span>
+      <div id="heatmap-actions">
+        <button id="heatmap-refresh-btn" class="btn-sm" title="Refresh data">🔄</button>
+        <button id="heatmap-export-btn" class="btn-sm" title="Export as CSV">📥 CSV</button>
+        <button id="heatmap-close-btn" class="btn-sm" title="Close panel">✕</button>
+      </div>
+    </div>
+    <div id="heatmap-stats"></div>
+    <div id="heatmap-grid"></div>
   </div>
 
   <!-- Model Selector Panel -->

--- a/style.css
+++ b/style.css
@@ -2628,3 +2628,136 @@ html.light .fork-notification {
   0%, 100% { border-color: #e94560; }
   50%      { border-color: #e9456080; }
 }
+
+/* ---------- Usage Heatmap ---------- */
+#heatmap-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 1099;
+}
+#heatmap-panel {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: var(--bg-secondary, #1e1e2e);
+  border: 1px solid var(--border, #333);
+  border-radius: 12px;
+  padding: 20px 24px;
+  z-index: 1100;
+  width: min(680px, 95vw);
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+}
+#heatmap-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+#heatmap-actions {
+  display: flex;
+  gap: 6px;
+}
+#heatmap-stats {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--border, #333);
+}
+.heatmap-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 80px;
+}
+.heatmap-stat-value {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--text-primary, #e0e0e0);
+}
+.heatmap-stat-label {
+  font-size: 0.75rem;
+  color: var(--text-secondary, #888);
+  margin-top: 2px;
+}
+#heatmap-grid {
+  overflow-x: auto;
+}
+.heatmap-row {
+  display: flex;
+  gap: 2px;
+  align-items: center;
+}
+.heatmap-header-row {
+  margin-bottom: 2px;
+}
+.heatmap-label {
+  width: 32px;
+  min-width: 32px;
+  font-size: 0.7rem;
+  color: var(--text-secondary, #888);
+  text-align: right;
+  padding-right: 6px;
+}
+.heatmap-hour-label {
+  width: 22px;
+  min-width: 22px;
+  font-size: 0.6rem;
+  color: var(--text-secondary, #888);
+  text-align: center;
+}
+.heatmap-cell {
+  width: 22px;
+  height: 22px;
+  min-width: 22px;
+  border-radius: 3px;
+  cursor: default;
+  transition: transform 0.1s;
+}
+.heatmap-cell:hover {
+  transform: scale(1.3);
+  z-index: 1;
+}
+.heatmap-level-0 { background: var(--heatmap-0, #161b22); }
+.heatmap-level-1 { background: var(--heatmap-1, #0e4429); }
+.heatmap-level-2 { background: var(--heatmap-2, #006d32); }
+.heatmap-level-3 { background: var(--heatmap-3, #26a641); }
+.heatmap-level-4 { background: var(--heatmap-4, #39d353); }
+
+.heatmap-legend {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  margin-top: 12px;
+  justify-content: flex-end;
+}
+.heatmap-legend-label {
+  font-size: 0.7rem;
+  color: var(--text-secondary, #888);
+  margin: 0 4px;
+}
+.heatmap-legend-cell {
+  width: 14px;
+  height: 14px;
+  min-width: 14px;
+  border-radius: 2px;
+}
+
+/* Light theme overrides */
+body.light-theme .heatmap-level-0 { background: #ebedf0; }
+body.light-theme .heatmap-level-1 { background: #9be9a8; }
+body.light-theme .heatmap-level-2 { background: #40c463; }
+body.light-theme .heatmap-level-3 { background: #30a14e; }
+body.light-theme .heatmap-level-4 { background: #216e39; }
+body.light-theme #heatmap-panel {
+  background: #fff;
+  border-color: #ddd;
+}

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -23,6 +23,7 @@ function setupDOM() {
       <button id="shortcuts-btn" class="btn-secondary">⌨️</button>
       <button id="stats-btn" class="btn-secondary" title="Chat statistics (Ctrl+I)">📊</button>
       <button id="cost-btn" class="btn-secondary" title="Cost dashboard">💰</button>
+      <button id="heatmap-btn" class="btn-secondary" title="Usage heatmap">🗓️</button>
       <button id="bookmarks-btn" title="Bookmarks (Ctrl+B)">🔖</button>
       <button id="voice-btn" class="btn-secondary" aria-label="Toggle voice input">🎤</button>
       <button id="theme-btn" class="btn-secondary" aria-label="Toggle theme">☀️</button>
@@ -224,6 +225,14 @@ function setupDOM() {
         </div>
       </div>
     </div>
+    <div id="heatmap-overlay" style="display:none;"></div>
+    <div id="heatmap-panel" style="display:none;">
+      <div id="heatmap-stats"></div>
+      <div id="heatmap-grid"></div>
+      <button id="heatmap-close-btn"></button>
+      <button id="heatmap-export-btn"></button>
+      <button id="heatmap-refresh-btn"></button>
+    </div>
     <div id="file-drop-overlay"></div>
   `;
 }
@@ -296,7 +305,8 @@ function loadApp() {
     'MessageTranslator',
     'MessageEditor',
     'MessageScheduler',
-    'SmartRetry'
+    'SmartRetry',
+    'UsageHeatmap'
   ];
 
   for (const mod of modules) {
@@ -316,9 +326,9 @@ function loadApp() {
     );
   }
 
-  // Suppress DOMContentLoaded listener (tests call functions directly)
-  appCode = appCode.replace(
-    /document\.addEventListener\('DOMContentLoaded'/,
+  // Suppress DOMContentLoaded listeners (tests call functions directly)
+  appCode = appCode.replaceAll(
+    "document.addEventListener('DOMContentLoaded'",
     "document.addEventListener('__test_skip_DOMContentLoaded__'"
   );
 

--- a/tests/usageHeatmap.test.js
+++ b/tests/usageHeatmap.test.js
@@ -1,0 +1,324 @@
+/**
+ * UsageHeatmap - Unit Tests
+ */
+
+const { setupDOM, loadApp } = require('./setup');
+
+function makeSession(name, msgs) {
+  return {
+    name,
+    messages: msgs,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+function injectSessions(sessions) {
+  localStorage.setItem('agenticchat_sessions', JSON.stringify(sessions));
+  // Force SessionManager cache invalidation by setting dirty flag
+  if (typeof SessionManager !== 'undefined' && SessionManager._invalidateCache) {
+    SessionManager._invalidateCache();
+  }
+}
+
+beforeEach(() => {
+  setupDOM();
+  loadApp();
+  localStorage.clear();
+  UsageHeatmap.init();
+});
+
+/* ================================================================
+ * Hour formatting
+ * ================================================================ */
+describe('UsageHeatmap._fmtHour', () => {
+  test('formats midnight', () => {
+    expect(UsageHeatmap._fmtHour(0)).toBe('12a');
+  });
+  test('formats morning hours', () => {
+    expect(UsageHeatmap._fmtHour(1)).toBe('1a');
+    expect(UsageHeatmap._fmtHour(11)).toBe('11a');
+  });
+  test('formats noon', () => {
+    expect(UsageHeatmap._fmtHour(12)).toBe('12p');
+  });
+  test('formats afternoon hours', () => {
+    expect(UsageHeatmap._fmtHour(13)).toBe('1p');
+    expect(UsageHeatmap._fmtHour(23)).toBe('11p');
+  });
+});
+
+/* ================================================================
+ * Intensity class mapping
+ * ================================================================ */
+describe('UsageHeatmap._intensityClass', () => {
+  test('returns level-0 for zero count', () => {
+    expect(UsageHeatmap._intensityClass(0, 100)).toBe('heatmap-level-0');
+  });
+  test('returns level-0 for zero max', () => {
+    expect(UsageHeatmap._intensityClass(5, 0)).toBe('heatmap-level-0');
+  });
+  test('returns level-1 for low ratio', () => {
+    expect(UsageHeatmap._intensityClass(10, 100)).toBe('heatmap-level-1');
+  });
+  test('returns level-2 for mid-low ratio', () => {
+    expect(UsageHeatmap._intensityClass(40, 100)).toBe('heatmap-level-2');
+  });
+  test('returns level-3 for mid-high ratio', () => {
+    expect(UsageHeatmap._intensityClass(70, 100)).toBe('heatmap-level-3');
+  });
+  test('returns level-4 for high ratio', () => {
+    expect(UsageHeatmap._intensityClass(90, 100)).toBe('heatmap-level-4');
+  });
+  test('returns level-4 for max count', () => {
+    expect(UsageHeatmap._intensityClass(100, 100)).toBe('heatmap-level-4');
+  });
+});
+
+/* ================================================================
+ * Data collection
+ * ================================================================ */
+describe('UsageHeatmap._collectData', () => {
+  test('returns empty grid with no sessions', () => {
+    const { grid, total, sessionCount } = UsageHeatmap._collectData();
+    expect(grid.length).toBe(7);
+    expect(grid[0].length).toBe(24);
+    expect(total).toBe(0);
+    expect(sessionCount).toBe(0);
+  });
+
+  test('counts messages in the correct day/hour slots', () => {
+    const monday2pm = new Date(2025, 0, 6, 14, 30, 0);
+    injectSessions([makeSession('s1', [
+      { role: 'user', content: 'x', timestamp: monday2pm.toISOString() }
+    ])]);
+
+    const { grid, total } = UsageHeatmap._collectData();
+    const day = monday2pm.getDay();
+    const hour = monday2pm.getHours();
+    expect(grid[day][hour]).toBe(1);
+    expect(total).toBe(1);
+  });
+
+  test('aggregates across multiple sessions', () => {
+    const d1 = new Date(2025, 0, 6, 10, 0);
+    const d2 = new Date(2025, 0, 6, 10, 30);
+    const d3 = new Date(2025, 0, 7, 15, 0);
+    injectSessions([
+      makeSession('s1', [
+        { role: 'user', content: 'a', timestamp: d1.toISOString() },
+        { role: 'assistant', content: 'b', timestamp: d2.toISOString() },
+      ]),
+      makeSession('s2', [
+        { role: 'user', content: 'c', timestamp: d3.toISOString() },
+      ]),
+    ]);
+
+    const { grid, total, sessionCount } = UsageHeatmap._collectData();
+    expect(sessionCount).toBe(2);
+    expect(total).toBe(3);
+    expect(grid[d1.getDay()][10]).toBe(2);
+    expect(grid[d3.getDay()][15]).toBe(1);
+  });
+
+  test('skips messages without timestamps', () => {
+    injectSessions([makeSession('s1', [
+      { role: 'user', content: 'no ts' },
+      { role: 'user', content: 'has ts', timestamp: new Date().toISOString() },
+    ])]);
+
+    const { total } = UsageHeatmap._collectData();
+    expect(total).toBe(1);
+  });
+
+  test('skips messages with invalid timestamps', () => {
+    injectSessions([makeSession('s1', [
+      { role: 'user', content: 'bad', timestamp: 'not-a-date' },
+    ])]);
+
+    const { total } = UsageHeatmap._collectData();
+    expect(total).toBe(0);
+  });
+});
+
+/* ================================================================
+ * Public API
+ * ================================================================ */
+describe('UsageHeatmap.getData', () => {
+  test('returns a 7x24 grid', () => {
+    const grid = UsageHeatmap.getData();
+    expect(grid.length).toBe(7);
+    for (const row of grid) {
+      expect(row.length).toBe(24);
+    }
+  });
+});
+
+describe('UsageHeatmap.getTotalMessages', () => {
+  test('returns 0 with no data', () => {
+    expect(UsageHeatmap.getTotalMessages()).toBe(0);
+  });
+});
+
+describe('UsageHeatmap.getPeakHour', () => {
+  test('returns null when no messages', () => {
+    expect(UsageHeatmap.getPeakHour()).toBeNull();
+  });
+
+  test('returns correct peak slot', () => {
+    const d = new Date(2025, 0, 8, 9, 0); // Wednesday 9am
+    const msgs = [];
+    for (let i = 0; i < 5; i++) {
+      msgs.push({ role: 'user', content: 'x', timestamp: new Date(d.getTime() + i * 60000).toISOString() });
+    }
+    injectSessions([makeSession('s1', msgs)]);
+
+    const peak = UsageHeatmap.getPeakHour();
+    expect(peak).not.toBeNull();
+    expect(peak.day).toBe(d.getDay());
+    expect(peak.hour).toBe(9);
+    expect(peak.count).toBe(5);
+    expect(peak.dayName).toBe('Wednesday');
+  });
+});
+
+describe('UsageHeatmap.getActiveHours', () => {
+  test('returns 0 with no data', () => {
+    expect(UsageHeatmap.getActiveHours()).toBe(0);
+  });
+
+  test('counts distinct active slots', () => {
+    const mon9 = new Date(2025, 0, 6, 9, 0);
+    const tue14 = new Date(2025, 0, 7, 14, 0);
+    injectSessions([makeSession('s1', [
+      { role: 'user', content: 'a', timestamp: mon9.toISOString() },
+      { role: 'user', content: 'b', timestamp: mon9.toISOString() },
+      { role: 'user', content: 'c', timestamp: tue14.toISOString() },
+    ])]);
+
+    expect(UsageHeatmap.getActiveHours()).toBe(2);
+  });
+});
+
+/* ================================================================
+ * Panel management
+ * ================================================================ */
+describe('UsageHeatmap panel', () => {
+  test('open shows panel and overlay', () => {
+    UsageHeatmap.open();
+    expect(document.getElementById('heatmap-panel').style.display).not.toBe('none');
+    expect(document.getElementById('heatmap-overlay').style.display).not.toBe('none');
+  });
+
+  test('close hides panel and overlay', () => {
+    UsageHeatmap.open();
+    UsageHeatmap.close();
+    expect(document.getElementById('heatmap-panel').style.display).toBe('none');
+    expect(document.getElementById('heatmap-overlay').style.display).toBe('none');
+  });
+
+  test('toggle opens then closes', () => {
+    UsageHeatmap.toggle();
+    expect(document.getElementById('heatmap-panel').style.display).not.toBe('none');
+    UsageHeatmap.toggle();
+    expect(document.getElementById('heatmap-panel').style.display).toBe('none');
+  });
+});
+
+/* ================================================================
+ * Rendering
+ * ================================================================ */
+describe('UsageHeatmap._render', () => {
+  test('renders grid with 7 day rows + 1 header + legend', () => {
+    UsageHeatmap._render();
+    const grid = document.getElementById('heatmap-grid');
+    const rows = grid.querySelectorAll('.heatmap-row');
+    expect(rows.length).toBe(8); // 1 header + 7 days
+  });
+
+  test('renders 24 cells per day row', () => {
+    UsageHeatmap._render();
+    const grid = document.getElementById('heatmap-grid');
+    const dayRows = grid.querySelectorAll('.heatmap-row:not(.heatmap-header-row)');
+    for (let i = 0; i < 7; i++) {
+      const cells = dayRows[i].querySelectorAll('.heatmap-cell');
+      expect(cells.length).toBe(24);
+    }
+  });
+
+  test('renders stats section', () => {
+    UsageHeatmap._render();
+    const stats = document.getElementById('heatmap-stats');
+    expect(stats.innerHTML).toContain('messages');
+    expect(stats.innerHTML).toContain('sessions scanned');
+  });
+
+  test('cells have correct data-count attributes', () => {
+    const d = new Date(2025, 0, 6, 10, 0);
+    injectSessions([makeSession('s1', [
+      { role: 'user', content: 'a', timestamp: d.toISOString() },
+      { role: 'user', content: 'b', timestamp: d.toISOString() },
+    ])]);
+
+    UsageHeatmap._render();
+    const grid = document.getElementById('heatmap-grid');
+    const dayRows = grid.querySelectorAll('.heatmap-row:not(.heatmap-header-row)');
+    const mondayRow = dayRows[d.getDay()];
+    const cells = mondayRow.querySelectorAll('.heatmap-cell');
+    expect(cells[10].getAttribute('data-count')).toBe('2');
+  });
+});
+
+/* ================================================================
+ * CSV export
+ * ================================================================ */
+describe('UsageHeatmap.exportCSV', () => {
+  test('generates valid CSV content', () => {
+    let capturedContent = '';
+    const origBlob = global.Blob;
+    global.Blob = jest.fn(([content]) => {
+      capturedContent = content;
+      return { size: content.length };
+    });
+    global.URL.createObjectURL = jest.fn(() => 'blob:test');
+    global.URL.revokeObjectURL = jest.fn();
+
+    const clickSpy = jest.fn();
+    jest.spyOn(document, 'createElement').mockReturnValue({
+      href: '',
+      download: '',
+      click: clickSpy,
+    });
+    jest.spyOn(document.body, 'appendChild').mockImplementation(() => {});
+    jest.spyOn(document.body, 'removeChild').mockImplementation(() => {});
+
+    UsageHeatmap.exportCSV();
+
+    expect(capturedContent).toContain('Day,');
+    expect(capturedContent).toContain('Sun,');
+    expect(capturedContent).toContain('Mon,');
+    expect(capturedContent).toContain('Sat,');
+    const lines = capturedContent.trim().split('\n');
+    expect(lines.length).toBe(8); // header + 7 days
+    expect(lines[0].split(',').length).toBe(25); // Day + 24 hours
+
+    global.Blob = origBlob;
+  });
+});
+
+/* ================================================================
+ * Init wiring
+ * ================================================================ */
+describe('UsageHeatmap.init', () => {
+  test('wires close button', () => {
+    UsageHeatmap.open();
+    document.getElementById('heatmap-close-btn').click();
+    expect(document.getElementById('heatmap-panel').style.display).toBe('none');
+  });
+
+  test('wires overlay click', () => {
+    UsageHeatmap.open();
+    document.getElementById('heatmap-overlay').click();
+    expect(document.getElementById('heatmap-panel').style.display).toBe('none');
+  });
+});


### PR DESCRIPTION
Module #42: Scans all saved sessions, renders a day-of-week x hour-of-day heatmap showing chat patterns. 5-level green intensity (GitHub contribution graph style). Stats: total messages, sessions scanned, active hours, peak slot. CSV export, dark/light themes, responsive. +775 lines, 32 tests.