### PR TITLE
docs: add performance and security issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/performance_issue.yml
+++ b/.github/ISSUE_TEMPLATE/performance_issue.yml
@@ -1,0 +1,102 @@
+---
+name: Performance Issue
+description: Report a performance problem (slow rendering, high memory, lag)
+title: "[Perf]: "
+labels: ["performance", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a performance issue! Since AgenticChat runs entirely in the browser,
+        performance details help us reproduce and fix the problem.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected Area
+      description: Which part of the app feels slow?
+      options:
+        - Chat input / message sending
+        - Code execution (sandbox)
+        - Conversation loading / switching
+        - Search (message or global)
+        - UI rendering / scrolling
+        - Session management
+        - Theme / visual updates
+        - Startup / initial load
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What's slow?
+      description: Describe the performance issue and when it occurs.
+      placeholder: |
+        e.g., "After ~50 messages in a conversation, scrolling becomes choppy and
+        typing in the input box has noticeable lag."
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to Reproduce
+      description: How can we trigger the performance issue?
+      placeholder: |
+        1. Open a conversation with 50+ messages
+        2. Scroll up and down rapidly
+        3. Notice dropped frames and lag
+
+  - type: input
+    id: message-count
+    attributes:
+      label: Approximate message count
+      description: How many messages are in the conversation when the issue occurs?
+      placeholder: "e.g., 100"
+
+  - type: dropdown
+    id: browser
+    attributes:
+      label: Browser
+      options:
+        - Chrome
+        - Firefox
+        - Safari
+        - Edge
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: browser-version
+    attributes:
+      label: Browser version
+      placeholder: "e.g., Chrome 133"
+
+  - type: dropdown
+    id: device
+    attributes:
+      label: Device type
+      options:
+        - Desktop / Laptop
+        - Tablet
+        - Mobile
+    validations:
+      required: true
+
+  - type: textarea
+    id: profiling
+    attributes:
+      label: Profiling data (optional)
+      description: |
+        If you can, open DevTools → Performance tab → Record the issue → share a screenshot
+        or the key findings (long tasks, layout thrashing, etc.)
+      placeholder: "e.g., Main thread blocked for 200ms during scroll handler"
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any other details — extensions, OS, memory usage, etc.

--- a/.github/ISSUE_TEMPLATE/security_concern.yml
+++ b/.github/ISSUE_TEMPLATE/security_concern.yml
@@ -1,0 +1,75 @@
+---
+name: Security Concern
+description: Report a security concern that is NOT a critical vulnerability (use Security Advisories for those)
+title: "[Security]: "
+labels: ["security", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **For critical security vulnerabilities**, please use
+        [Security Advisories](https://github.com/sauravbhattacharya001/agenticchat/security/advisories/new)
+        for private disclosure. This template is for non-critical security concerns,
+        hardening suggestions, or sandbox escape observations.
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Security Category
+      description: What type of security concern is this?
+      options:
+        - Sandbox escape / bypass
+        - API key exposure risk
+        - Content Security Policy gap
+        - Cross-site scripting (XSS)
+        - Prompt injection / manipulation
+        - Data leakage (localStorage, etc.)
+        - Insecure default configuration
+        - Missing input validation
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Estimated Severity
+      options:
+        - Low — defense-in-depth improvement
+        - Medium — exploitable under specific conditions
+        - High — easily exploitable, significant impact
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe the security concern in detail.
+      placeholder: |
+        e.g., "The sandbox CSP allows connect-src https: which means LLM-generated code
+        can exfiltrate injected service API keys to any HTTPS endpoint."
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to Reproduce (if applicable)
+      description: How can the concern be demonstrated?
+      placeholder: |
+        1. Enter a prompt that asks the AI to make an HTTP request
+        2. Observe that the sandbox can reach any HTTPS endpoint
+        3. ...
+
+  - type: textarea
+    id: mitigation
+    attributes:
+      label: Suggested Mitigation
+      description: If you have ideas on how to fix or mitigate this, share them here.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any references, links, or related issues.


### PR DESCRIPTION
Adds two new issue templates alongside existing bug report and feature request:

**Performance Issue** (\performance_issue.yml\):
- Affected area dropdown (chat input, sandbox, search, rendering, session mgmt, etc.)
- Browser + device type + version fields
- Message count context (critical for reproducing scaling issues)
- Optional profiling data section with DevTools guidance

**Security Concern** (\security_concern.yml\):
- Prominent link to Security Advisories for critical vulnerabilities (private disclosure)
- Category dropdown: sandbox escape, API key exposure, CSP gaps, XSS, prompt injection, data leakage, etc.
- Severity estimation (low/medium/high)
- Suggested mitigation field
- Designed for non-critical hardening suggestions and observations

Both templates use GitHub's YAML form format with appropriate labels (\performance\/\security\ + \	riage\).