### PR TITLE
feat: ContextWindowMeter -- real-time context window usage indicator

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 /* ============================================================
  * Agentic Chat — Application Logic
  *
- * Architecture (40 modules, all revealing-module-pattern IIFEs):
+ * Architecture (41 modules, all revealing-module-pattern IIFEs):
  *
  *   Core:
  *   SafeStorage          — safe localStorage wrapper for restricted-storage environments
@@ -16036,3 +16036,166 @@ const UsageHeatmap = (() => {
 })();
 
 document.addEventListener('DOMContentLoaded', UsageHeatmap.init);
+
+
+// ═══════════════════════════════════════════════════════════════════
+//  Context Window Meter
+// ═══════════════════════════════════════════════════════════════════
+/**
+ * ContextWindowMeter — real-time visual indicator of context window usage.
+ *
+ * Shows a persistent progress bar between the char-count and chat output
+ * areas, displaying how much of the model's MAX_TOTAL_TOKENS budget the
+ * current conversation consumes.  Color-coded:
+ *   green  (<60%)  — plenty of room
+ *   yellow (60-80%) — getting full
+ *   red    (>80%)  — near limit, messages will be trimmed soon
+ *
+ * The meter hooks into ConversationManager.estimateTokens() and updates
+ * automatically on every UI refresh cycle via a MutationObserver on the
+ * chat output container.  It also exposes a manual refresh() for modules
+ * that modify history programmatically (e.g. ConversationMerge, clear).
+ *
+ * @namespace ContextWindowMeter
+ */
+const ContextWindowMeter = (() => {
+  'use strict';
+
+  // ── Thresholds ──────────────────────────────────────────────────
+  const YELLOW_THRESHOLD = 0.60;
+  const RED_THRESHOLD    = 0.80;
+
+  // ── DOM refs (lazily resolved) ──────────────────────────────────
+  let _container = null;
+  let _fill      = null;
+  let _label     = null;
+  let _observer  = null;
+  let _visible   = true;
+
+  function _el(id) { return document.getElementById(id); }
+
+  function _ensureEls() {
+    if (!_container) _container = _el('context-meter');
+    if (!_fill)      _fill      = _el('context-meter-fill');
+    if (!_label)     _label     = _el('context-meter-label');
+  }
+
+  // ── Color class helper ──────────────────────────────────────────
+  function _colorClass(ratio) {
+    if (ratio >= RED_THRESHOLD)    return 'context-meter__fill--red';
+    if (ratio >= YELLOW_THRESHOLD) return 'context-meter__fill--yellow';
+    return 'context-meter__fill--green';
+  }
+
+  // ── Format helpers ──────────────────────────────────────────────
+  function _fmtK(n) {
+    return n >= 1000 ? (n / 1000).toFixed(1) + 'k' : String(n);
+  }
+
+  // ── Core update ─────────────────────────────────────────────────
+  function refresh() {
+    _ensureEls();
+    if (!_container || !_fill || !_label) return;
+
+    if (typeof ConversationManager === 'undefined') return;
+
+    const used = ConversationManager.estimateTokens();
+    const max  = ChatConfig.MAX_TOTAL_TOKENS;
+    const ratio = Math.min(used / max, 1);
+    const pct   = Math.round(ratio * 100);
+
+    // Update progress bar
+    _fill.style.width = pct + '%';
+
+    // Update color
+    _fill.className = 'context-meter__fill ' + _colorClass(ratio);
+
+    // Update label
+    _label.textContent = _fmtK(used) + ' / ' + _fmtK(max) + ' tokens (' + pct + '%)';
+
+    // Update ARIA
+    _container.setAttribute('aria-valuenow', String(pct));
+
+    // Show/hide: hide when conversation is empty (just system prompt)
+    const msgs = ConversationManager.getMessages();
+    const hasContent = msgs.length > 1;  // more than just system prompt
+    if (hasContent && !_visible) {
+      _container.classList.remove('context-meter--hidden');
+      _visible = true;
+    } else if (!hasContent && _visible) {
+      _container.classList.add('context-meter--hidden');
+      _visible = false;
+    }
+  }
+
+  // ── Visibility toggle ──────────────────────────────────────────
+  function toggle() {
+    _ensureEls();
+    if (!_container) return _visible;
+    _visible = !_visible;
+    _container.style.display = _visible ? '' : 'none';
+    try { SafeStorage.set('ac-context-meter-visible', JSON.stringify(_visible)); } catch (_) {}
+    return _visible;
+  }
+
+  // ── Observer: watch chat output for changes ─────────────────────
+  function _startObserver() {
+    const chatOutput = _el('output');
+    if (!chatOutput) return;
+
+    _observer = new MutationObserver(() => {
+      // Debounce: requestAnimationFrame coalesces rapid mutations
+      requestAnimationFrame(refresh);
+    });
+
+    _observer.observe(chatOutput, { childList: true, subtree: true });
+  }
+
+  // ── Init ────────────────────────────────────────────────────────
+  function init() {
+    _ensureEls();
+    if (!_container) return;
+
+    // Restore visibility preference
+    try {
+      const saved = SafeStorage.get('ac-context-meter-visible');
+      if (saved === 'false') {
+        _container.style.display = 'none';
+        _visible = false;
+      }
+    } catch (_) {}
+
+    // Initial render (hidden if conversation is empty)
+    _container.classList.add('context-meter--hidden');
+    _visible = false;
+    refresh();
+
+    // Start watching for conversation changes
+    _startObserver();
+
+    // Also refresh on storage events (cross-tab session switches)
+    window.addEventListener('storage', (e) => {
+      if (e.key && e.key.startsWith('ac-session')) {
+        setTimeout(refresh, 100);
+      }
+    });
+  }
+
+  function destroy() {
+    if (_observer) { _observer.disconnect(); _observer = null; }
+  }
+
+  return {
+    init,
+    refresh,
+    toggle,
+    destroy,
+    // Exposed for testing
+    _colorClass,
+    _fmtK,
+    YELLOW_THRESHOLD,
+    RED_THRESHOLD
+  };
+})();
+
+document.addEventListener('DOMContentLoaded', ContextWindowMeter.init);

--- a/index.html
+++ b/index.html
@@ -59,6 +59,12 @@
   <div class="zen-indicator">Focus Mode — press <kbd>Ctrl+Shift+F</kbd> or <kbd>Esc</kbd> to exit</div>
 
   <div id="char-count"></div>
+  <div id="context-meter" class="context-meter" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Context window usage">
+    <div class="context-meter__bar">
+      <div class="context-meter__fill" id="context-meter-fill"></div>
+    </div>
+    <span class="context-meter__label" id="context-meter-label"></span>
+  </div>
   <div id="last-prompt">(no input yet)</div>
 
   <div id="blackbox">

--- a/style.css
+++ b/style.css
@@ -2761,3 +2761,42 @@ body.light-theme #heatmap-panel {
   background: #fff;
   border-color: #ddd;
 }
+
+
+/* --- Context Window Meter --- */
+.context-meter {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 2px 12px;
+  font-size: 0.75rem;
+  color: #9ca3af;
+  transition: opacity 0.3s ease;
+}
+.context-meter--hidden { opacity: 0; pointer-events: none; }
+.context-meter__bar {
+  flex: 1;
+  height: 6px;
+  background: #1f2937;
+  border-radius: 3px;
+  overflow: hidden;
+  max-width: 200px;
+}
+.context-meter__fill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.3s ease, background-color 0.3s ease;
+  width: 0;
+}
+.context-meter__fill--green  { background-color: #22c55e; }
+.context-meter__fill--yellow { background-color: #eab308; }
+.context-meter__fill--red    { background-color: #ef4444; }
+.context-meter__label {
+  white-space: nowrap;
+  min-width: 100px;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Light theme overrides */
+[data-theme="light"] .context-meter__bar { background: #e5e7eb; }
+[data-theme="light"] .context-meter { color: #6b7280; }

--- a/tests/context-meter.test.js
+++ b/tests/context-meter.test.js
@@ -1,0 +1,204 @@
+/**
+ * ContextWindowMeter - Unit Tests
+ */
+
+const { setupDOM, loadApp } = require('./setup');
+
+beforeEach(() => {
+  setupDOM();
+  loadApp();
+  localStorage.clear();
+});
+
+describe('ContextWindowMeter', () => {
+  // ── _colorClass ─────────────────────────────────────────────────
+  describe('_colorClass', () => {
+    test('returns green for ratio < 0.60', () => {
+      expect(ContextWindowMeter._colorClass(0)).toBe('context-meter__fill--green');
+      expect(ContextWindowMeter._colorClass(0.3)).toBe('context-meter__fill--green');
+      expect(ContextWindowMeter._colorClass(0.59)).toBe('context-meter__fill--green');
+    });
+
+    test('returns yellow for ratio 0.60-0.79', () => {
+      expect(ContextWindowMeter._colorClass(0.60)).toBe('context-meter__fill--yellow');
+      expect(ContextWindowMeter._colorClass(0.70)).toBe('context-meter__fill--yellow');
+      expect(ContextWindowMeter._colorClass(0.79)).toBe('context-meter__fill--yellow');
+    });
+
+    test('returns red for ratio >= 0.80', () => {
+      expect(ContextWindowMeter._colorClass(0.80)).toBe('context-meter__fill--red');
+      expect(ContextWindowMeter._colorClass(0.95)).toBe('context-meter__fill--red');
+      expect(ContextWindowMeter._colorClass(1.0)).toBe('context-meter__fill--red');
+    });
+  });
+
+  // ── _fmtK ──────────────────────────────────────────────────────
+  describe('_fmtK', () => {
+    test('formats small numbers without suffix', () => {
+      expect(ContextWindowMeter._fmtK(0)).toBe('0');
+      expect(ContextWindowMeter._fmtK(500)).toBe('500');
+      expect(ContextWindowMeter._fmtK(999)).toBe('999');
+    });
+
+    test('formats thousands with k suffix', () => {
+      expect(ContextWindowMeter._fmtK(1000)).toBe('1.0k');
+      expect(ContextWindowMeter._fmtK(2500)).toBe('2.5k');
+      expect(ContextWindowMeter._fmtK(100000)).toBe('100.0k');
+    });
+  });
+
+  // ── Thresholds ──────────────────────────────────────────────────
+  describe('thresholds', () => {
+    test('YELLOW_THRESHOLD is 0.60', () => {
+      expect(ContextWindowMeter.YELLOW_THRESHOLD).toBe(0.60);
+    });
+
+    test('RED_THRESHOLD is 0.80', () => {
+      expect(ContextWindowMeter.RED_THRESHOLD).toBe(0.80);
+    });
+  });
+
+  // ── init ────────────────────────────────────────────────────────
+  describe('init', () => {
+    test('initializes without errors', () => {
+      expect(() => ContextWindowMeter.init()).not.toThrow();
+    });
+
+    test('meter starts hidden when conversation is empty', () => {
+      ContextWindowMeter.init();
+      const container = document.getElementById('context-meter');
+      expect(container.classList.contains('context-meter--hidden')).toBe(true);
+    });
+  });
+
+  // ── refresh ─────────────────────────────────────────────────────
+  describe('refresh', () => {
+    test('updates fill width based on token usage', () => {
+      // Add some messages to generate token count
+      ConversationManager.addMessage('user', 'Hello world! '.repeat(100));
+      ConversationManager.addMessage('assistant', 'Response text. '.repeat(100));
+      ContextWindowMeter.refresh();
+
+      const fill = document.getElementById('context-meter-fill');
+      expect(fill.style.width).not.toBe('0%');
+    });
+
+    test('shows green color for low usage', () => {
+      // Small message — well below 60%
+      ConversationManager.addMessage('user', 'Hi');
+      ContextWindowMeter.refresh();
+
+      const fill = document.getElementById('context-meter-fill');
+      expect(fill.className).toContain('context-meter__fill--green');
+    });
+
+    test('updates label with token count', () => {
+      ConversationManager.addMessage('user', 'test message');
+      ContextWindowMeter.refresh();
+
+      const label = document.getElementById('context-meter-label');
+      expect(label.textContent).toMatch(/tokens/);
+      expect(label.textContent).toMatch(/\d+/);
+      expect(label.textContent).toMatch(/%/);
+    });
+
+    test('updates ARIA valuenow', () => {
+      ConversationManager.addMessage('user', 'test');
+      ContextWindowMeter.refresh();
+
+      const container = document.getElementById('context-meter');
+      const val = parseInt(container.getAttribute('aria-valuenow'));
+      expect(val).toBeGreaterThanOrEqual(0);
+      expect(val).toBeLessThanOrEqual(100);
+    });
+
+    test('makes meter visible when conversation has messages', () => {
+      ContextWindowMeter.init(); // starts hidden
+      const container = document.getElementById('context-meter');
+      expect(container.classList.contains('context-meter--hidden')).toBe(true);
+
+      ConversationManager.addMessage('user', 'Hello');
+      ContextWindowMeter.refresh();
+      expect(container.classList.contains('context-meter--hidden')).toBe(false);
+    });
+
+    test('hides meter when conversation is cleared', () => {
+      ConversationManager.addMessage('user', 'Hello');
+      ContextWindowMeter.refresh();
+      const container = document.getElementById('context-meter');
+      expect(container.classList.contains('context-meter--hidden')).toBe(false);
+
+      ConversationManager.clear();
+      ContextWindowMeter.refresh();
+      expect(container.classList.contains('context-meter--hidden')).toBe(true);
+    });
+
+    test('handles missing DOM elements gracefully', () => {
+      // Remove the meter from DOM
+      const meter = document.getElementById('context-meter');
+      if (meter) meter.remove();
+      expect(() => ContextWindowMeter.refresh()).not.toThrow();
+    });
+  });
+
+  // ── toggle ──────────────────────────────────────────────────────
+  describe('toggle', () => {
+    test('hides the meter on first toggle', () => {
+      const visible = ContextWindowMeter.toggle();
+      expect(visible).toBe(false);
+      const container = document.getElementById('context-meter');
+      expect(container.style.display).toBe('none');
+    });
+
+    test('shows the meter on second toggle', () => {
+      ContextWindowMeter.toggle(); // hide
+      const visible = ContextWindowMeter.toggle(); // show
+      expect(visible).toBe(true);
+      const container = document.getElementById('context-meter');
+      expect(container.style.display).toBe('');
+    });
+
+    test('persists visibility preference', () => {
+      ContextWindowMeter.toggle(); // hide
+      expect(localStorage.getItem('ac-context-meter-visible')).toBe('false');
+    });
+  });
+
+  // ── destroy ─────────────────────────────────────────────────────
+  describe('destroy', () => {
+    test('disconnects observer without errors', () => {
+      ContextWindowMeter.init();
+      expect(() => ContextWindowMeter.destroy()).not.toThrow();
+    });
+
+    test('can be called multiple times safely', () => {
+      ContextWindowMeter.init();
+      ContextWindowMeter.destroy();
+      expect(() => ContextWindowMeter.destroy()).not.toThrow();
+    });
+  });
+
+  // ── Integration ─────────────────────────────────────────────────
+  describe('integration', () => {
+    test('percentage increases as messages accumulate', () => {
+      ContextWindowMeter.init();
+      ConversationManager.addMessage('user', 'First message');
+      ContextWindowMeter.refresh();
+      const pct1 = parseInt(document.getElementById('context-meter').getAttribute('aria-valuenow'));
+
+      ConversationManager.addMessage('assistant', 'A much longer response with lots of detail. '.repeat(50));
+      ContextWindowMeter.refresh();
+      const pct2 = parseInt(document.getElementById('context-meter').getAttribute('aria-valuenow'));
+
+      expect(pct2).toBeGreaterThan(pct1);
+    });
+
+    test('label format matches expected pattern', () => {
+      ConversationManager.addMessage('user', 'x'.repeat(4000));
+      ContextWindowMeter.refresh();
+      const label = document.getElementById('context-meter-label');
+      // Should be something like "1.0k / 100.0k tokens (1%)"
+      expect(label.textContent).toMatch(/^\d[\d.]*k?\s*\/\s*\d[\d.]*k?\s*tokens\s*\(\d+%\)$/);
+    });
+  });
+});

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -29,6 +29,12 @@ function setupDOM() {
       <button id="theme-btn" class="btn-secondary" aria-label="Toggle theme">☀️</button>
     </div>
     <div id="char-count"></div>
+    <div id="context-meter" class="context-meter" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Context window usage">
+      <div class="context-meter__bar">
+        <div class="context-meter__fill" id="context-meter-fill"></div>
+      </div>
+      <span class="context-meter__label" id="context-meter-label"></span>
+    </div>
     <div id="last-prompt">(no input yet)</div>
     <div id="blackbox">
       <div id="search-bar" class="search-bar" role="search" aria-label="Search messages" style="display:none;">
@@ -306,7 +312,8 @@ function loadApp() {
     'MessageEditor',
     'MessageScheduler',
     'SmartRetry',
-    'UsageHeatmap'
+    'UsageHeatmap',
+    'ContextWindowMeter'
   ];
 
   for (const mod of modules) {


### PR DESCRIPTION
Adds a persistent progress bar showing how much of the model's token budget the current conversation consumes.

## Features
- **Color-coded progress bar**: green (<60%), yellow (60-80%), red (>80%)
- **Real-time updates** via MutationObserver on chat output container
- **Compact label**: \2.5k / 100.0k tokens (3%)\ with tabular-nums font variant
- **Auto-hides** when conversation is empty (just system prompt)
- **Toggle visibility** via \ContextWindowMeter.toggle()\ — persists in localStorage
- **ARIA progressbar** role with live \ria-valuenow\
- **Light/dark theme** support
- **Cross-tab sync** — refreshes on storage events

## Why
The app has \TOKEN_WARNING_THRESHOLD\ but it only logs a console warning at 80%. Users have no visibility into how much context they're consuming until they hit the limit and messages start getting trimmed. This meter gives continuous feedback.

## Files
- \index.html\: progress bar element between char-count and chat output
- \style.css\: \.context-meter\ with green/yellow/red fill variants
- \pp.js\: ContextWindowMeter IIFE (module #41)
- \	ests/setup.js\: DOM + module list update
- \	ests/context-meter.test.js\: 23 tests

+421 lines | 5 files | 23 tests