### PR TITLE
feat: AutoTitle — AI-generated session titles after first exchange

### DIFF
--- a/app.js
+++ b/app.js
@@ -52,6 +52,7 @@
  *   ConversationReplay   — message-by-message playback with transport controls
  *   PromptLibrary        — user-created prompt snippets with folders, search, usage tracking, import/export
  *   MessageTranslator    — inline message translation to 20+ languages via OpenAI API
+ *   AutoTitle            — automatic AI-generated session titles after first exchange
  *   MessageEditor        — edit & resend user messages (truncate + reload into input)
  *   SmartRetry           — automatic retry with exponential backoff for transient API failures
  *   UsageHeatmap         — GitHub-style 7×24 activity heatmap across all sessions
@@ -1132,6 +1133,11 @@ const ChatController = (() => {
 
       // Auto-save session if enabled
       SessionManager.autoSaveIfEnabled();
+
+      // Auto-generate session title after first exchange (only when auto-save is active)
+      if (SessionManager.isAutoSaveEnabled()) {
+        try { AutoTitle.onMessageComplete(); } catch (_) {}
+      }
     } catch (err) {
       if (err.name === 'AbortError') {
         UIController.setChatOutput('(request cancelled)');
@@ -16193,3 +16199,133 @@ const ContextWindowMeter = (() => {
 })();
 
 document.addEventListener('DOMContentLoaded', ContextWindowMeter.init);
+
+/* ============================================================
+ * AutoTitle — AI-generated session titles after first exchange
+ *
+ * After the first assistant response in a session, sends a lightweight
+ * API call (gpt-4o-mini, 20 max tokens) to generate a concise,
+ * descriptive title and updates the session name automatically.
+ * Enabled by default; toggle via AutoTitle.setEnabled(bool).
+ * ============================================================ */
+
+/**
+ * @namespace AutoTitle
+ */
+const AutoTitle = (() => {
+  const ENABLED_KEY = 'agenticchat_autotitle';
+  const TITLED_KEY = 'agenticchat_autotitled_sessions';
+  const TITLE_MODEL = 'gpt-4o-mini';
+
+  function isEnabled() {
+    const val = SafeStorage.get(ENABLED_KEY);
+    return val === null || val === 'true';
+  }
+
+  function setEnabled(enabled) {
+    SafeStorage.set(ENABLED_KEY, String(enabled));
+  }
+
+  function _getTitledSet() {
+    try {
+      const raw = SafeStorage.get(TITLED_KEY);
+      return raw ? new Set(JSON.parse(raw)) : new Set();
+    } catch { return new Set(); }
+  }
+
+  function _markTitled(sessionId) {
+    const set = _getTitledSet();
+    set.add(sessionId);
+    const arr = [...set];
+    if (arr.length > 200) arr.splice(0, arr.length - 200);
+    SafeStorage.set(TITLED_KEY, JSON.stringify(arr));
+  }
+
+  function _alreadyTitled(sessionId) {
+    return _getTitledSet().has(sessionId);
+  }
+
+  async function generateTitle(userMessage, assistantReply, sessionId) {
+    if (!isEnabled()) return;
+    if (!sessionId) return;
+    if (_alreadyTitled(sessionId)) return;
+
+    const apiKey = ApiKeyManager.getOpenAIKey();
+    if (!apiKey) return;
+
+    _markTitled(sessionId);
+
+    try {
+      const truncatedUser = userMessage.substring(0, 500);
+      const truncatedReply = assistantReply.substring(0, 500);
+
+      const rsp = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${apiKey}`
+        },
+        body: JSON.stringify({
+          model: TITLE_MODEL,
+          messages: [
+            {
+              role: 'system',
+              content: 'Generate a concise title (3-7 words, no quotes, no period) for this conversation. Reply with ONLY the title text.'
+            },
+            {
+              role: 'user',
+              content: `User: ${truncatedUser}\n\nAssistant: ${truncatedReply}`
+            }
+          ],
+          max_tokens: 20,
+          temperature: 0.5
+        })
+      });
+
+      if (!rsp.ok) return;
+
+      const data = await rsp.json();
+      const title = data.choices?.[0]?.message?.content?.trim();
+      if (!title || title.length < 2 || title.length > 100) return;
+
+      const cleaned = title.replace(/^["'"\u201C\u201D\u2018\u2019]+|["'"\u201C\u201D\u2018\u2019]+$/g, '').replace(/\.+$/, '');
+      if (!cleaned || cleaned.length < 2) return;
+
+      _applyTitle(sessionId, cleaned);
+    } catch {
+      // Non-critical — silently fail
+    }
+  }
+
+  function _applyTitle(sessionId, title) {
+    try {
+      const raw = SafeStorage.get('agenticchat_sessions');
+      if (!raw) return;
+      const sessions = JSON.parse(raw);
+      const session = sessions.find(s => s.id === sessionId);
+      if (!session) return;
+
+      session.name = title;
+      SafeStorage.set('agenticchat_sessions', JSON.stringify(sessions));
+
+      try { SessionManager.refresh(); } catch {}
+      try { SessionManager.invalidateCache(); } catch {}
+    } catch {}
+  }
+
+  function onMessageComplete() {
+    if (!isEnabled()) return;
+
+    const messages = ConversationManager.getMessages().filter(m => m.role !== 'system');
+    const userMsgs = messages.filter(m => m.role === 'user');
+    const assistantMsgs = messages.filter(m => m.role === 'assistant');
+    if (userMsgs.length !== 1 || assistantMsgs.length !== 1) return;
+
+    const activeId = SafeStorage.get('agenticchat_active_session');
+    if (!activeId) return;
+
+    generateTitle(userMsgs[0].content, assistantMsgs[0].content, activeId);
+  }
+
+  return { isEnabled, setEnabled, generateTitle, onMessageComplete, _applyTitle, _markTitled, _alreadyTitled, _getTitledSet };
+})();

--- a/tests/auto-title.test.js
+++ b/tests/auto-title.test.js
@@ -1,0 +1,344 @@
+/**
+ * @file tests/auto-title.test.js
+ * Tests for the AutoTitle module — AI-generated session titles.
+ */
+
+const { setupDOM, loadApp } = require('./setup');
+
+beforeEach(() => {
+  setupDOM();
+  loadApp();
+  localStorage.clear();
+});
+
+describe('AutoTitle', () => {
+  describe('isEnabled / setEnabled', () => {
+    test('enabled by default when no storage key exists', () => {
+      expect(AutoTitle.isEnabled()).toBe(true);
+    });
+
+    test('returns true when storage key is "true"', () => {
+      localStorage.setItem('agenticchat_autotitle', 'true');
+      expect(AutoTitle.isEnabled()).toBe(true);
+    });
+
+    test('returns false when storage key is "false"', () => {
+      localStorage.setItem('agenticchat_autotitle', 'false');
+      expect(AutoTitle.isEnabled()).toBe(false);
+    });
+
+    test('setEnabled(false) disables auto-title', () => {
+      AutoTitle.setEnabled(false);
+      expect(AutoTitle.isEnabled()).toBe(false);
+      expect(localStorage.getItem('agenticchat_autotitle')).toBe('false');
+    });
+
+    test('setEnabled(true) enables auto-title', () => {
+      AutoTitle.setEnabled(false);
+      AutoTitle.setEnabled(true);
+      expect(AutoTitle.isEnabled()).toBe(true);
+    });
+  });
+
+  describe('_markTitled / _alreadyTitled', () => {
+    test('session is not titled by default', () => {
+      expect(AutoTitle._alreadyTitled('sess-1')).toBe(false);
+    });
+
+    test('marks a session as titled', () => {
+      AutoTitle._markTitled('sess-1');
+      expect(AutoTitle._alreadyTitled('sess-1')).toBe(true);
+    });
+
+    test('multiple sessions can be titled', () => {
+      AutoTitle._markTitled('sess-1');
+      AutoTitle._markTitled('sess-2');
+      expect(AutoTitle._alreadyTitled('sess-1')).toBe(true);
+      expect(AutoTitle._alreadyTitled('sess-2')).toBe(true);
+    });
+
+    test('titled set caps at 200 entries', () => {
+      for (let i = 0; i < 210; i++) {
+        AutoTitle._markTitled(`sess-${i}`);
+      }
+      const set = AutoTitle._getTitledSet();
+      expect(set.size).toBeLessThanOrEqual(200);
+      expect(set.has('sess-209')).toBe(true);
+    });
+  });
+
+  describe('_applyTitle', () => {
+    test('updates session name in storage', () => {
+      const sessions = [{
+        id: 'test-123', name: 'Old Name', messages: [],
+        messageCount: 0, preview: '',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
+      }];
+      localStorage.setItem('agenticchat_sessions', JSON.stringify(sessions));
+
+      AutoTitle._applyTitle('test-123', 'New AI Title');
+
+      const updated = JSON.parse(localStorage.getItem('agenticchat_sessions'));
+      expect(updated[0].name).toBe('New AI Title');
+    });
+
+    test('does nothing if session ID not found', () => {
+      const sessions = [{
+        id: 'test-123', name: 'Original', messages: [],
+        messageCount: 0, preview: '',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
+      }];
+      localStorage.setItem('agenticchat_sessions', JSON.stringify(sessions));
+
+      AutoTitle._applyTitle('nonexistent', 'Title');
+
+      const updated = JSON.parse(localStorage.getItem('agenticchat_sessions'));
+      expect(updated[0].name).toBe('Original');
+    });
+
+    test('does nothing if no sessions in storage', () => {
+      expect(() => AutoTitle._applyTitle('any', 'Title')).not.toThrow();
+    });
+  });
+
+  describe('generateTitle', () => {
+    test('skips when disabled', async () => {
+      AutoTitle.setEnabled(false);
+      global.fetch = jest.fn();
+      await AutoTitle.generateTitle('hello', 'world', 'sess-1');
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    test('skips when no session ID', async () => {
+      global.fetch = jest.fn();
+      await AutoTitle.generateTitle('hello', 'world', null);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    test('skips when session already titled', async () => {
+      AutoTitle._markTitled('sess-1');
+      global.fetch = jest.fn();
+      await AutoTitle.generateTitle('hello', 'world', 'sess-1');
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    test('skips when no API key', async () => {
+      global.fetch = jest.fn();
+      await AutoTitle.generateTitle('hello', 'world', 'sess-new');
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    test('calls API and applies title on success', async () => {
+      ApiKeyManager.setOpenAIKey('sk-test-key-1234567890abcdefghijklmnopq');
+      const sessions = [{
+        id: 'sess-gen', name: 'hello', messages: [],
+        messageCount: 1, preview: 'hello',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
+      }];
+      localStorage.setItem('agenticchat_sessions', JSON.stringify(sessions));
+
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          choices: [{ message: { content: 'Greeting the AI Assistant' } }]
+        })
+      });
+
+      await AutoTitle.generateTitle('hello there', 'Hi! How can I help?', 'sess-gen');
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      const callBody = JSON.parse(global.fetch.mock.calls[0][1].body);
+      expect(callBody.model).toBe('gpt-4o-mini');
+      expect(callBody.max_tokens).toBe(20);
+
+      const updated = JSON.parse(localStorage.getItem('agenticchat_sessions'));
+      expect(updated[0].name).toBe('Greeting the AI Assistant');
+    });
+
+    test('strips surrounding quotes from title', async () => {
+      ApiKeyManager.setOpenAIKey('sk-test-key-1234567890abcdefghijklmnopq');
+      const sessions = [{
+        id: 'sess-q', name: 'old', messages: [],
+        messageCount: 1, preview: '',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
+      }];
+      localStorage.setItem('agenticchat_sessions', JSON.stringify(sessions));
+
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          choices: [{ message: { content: '"Python List Sorting"' } }]
+        })
+      });
+
+      await AutoTitle.generateTitle('sort list', 'Use sorted()', 'sess-q');
+
+      const updated = JSON.parse(localStorage.getItem('agenticchat_sessions'));
+      expect(updated[0].name).toBe('Python List Sorting');
+    });
+
+    test('removes trailing periods from title', async () => {
+      ApiKeyManager.setOpenAIKey('sk-test-key-1234567890abcdefghijklmnopq');
+      const sessions = [{
+        id: 'sess-p', name: 'old', messages: [],
+        messageCount: 1, preview: '',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
+      }];
+      localStorage.setItem('agenticchat_sessions', JSON.stringify(sessions));
+
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          choices: [{ message: { content: 'JavaScript Array Methods.' } }]
+        })
+      });
+
+      await AutoTitle.generateTitle('arrays', 'Use map/filter', 'sess-p');
+
+      const updated = JSON.parse(localStorage.getItem('agenticchat_sessions'));
+      expect(updated[0].name).toBe('JavaScript Array Methods');
+    });
+
+    test('handles API failure gracefully', async () => {
+      ApiKeyManager.setOpenAIKey('sk-test-key-1234567890abcdefghijklmnopq');
+      global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 500 });
+
+      await expect(
+        AutoTitle.generateTitle('hello', 'world', 'sess-fail')
+      ).resolves.not.toThrow();
+    });
+
+    test('handles network error gracefully', async () => {
+      ApiKeyManager.setOpenAIKey('sk-test-key-1234567890abcdefghijklmnopq');
+      global.fetch = jest.fn().mockRejectedValue(new Error('Network failure'));
+
+      await expect(
+        AutoTitle.generateTitle('hello', 'world', 'sess-net')
+      ).resolves.not.toThrow();
+    });
+
+    test('prevents duplicate calls for same session', async () => {
+      ApiKeyManager.setOpenAIKey('sk-test-key-1234567890abcdefghijklmnopq');
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          choices: [{ message: { content: 'Title' } }]
+        })
+      });
+
+      await AutoTitle.generateTitle('hello', 'world', 'sess-dup');
+      await AutoTitle.generateTitle('hello', 'world', 'sess-dup');
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    test('rejects titles that are too short', async () => {
+      ApiKeyManager.setOpenAIKey('sk-test-key-1234567890abcdefghijklmnopq');
+      const sessions = [{
+        id: 'sess-short', name: 'original', messages: [],
+        messageCount: 1, preview: '',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
+      }];
+      localStorage.setItem('agenticchat_sessions', JSON.stringify(sessions));
+
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          choices: [{ message: { content: 'X' } }]
+        })
+      });
+
+      await AutoTitle.generateTitle('hello', 'world', 'sess-short');
+
+      const updated = JSON.parse(localStorage.getItem('agenticchat_sessions'));
+      expect(updated[0].name).toBe('original');
+    });
+
+    test('truncates long user messages for API call', async () => {
+      ApiKeyManager.setOpenAIKey('sk-test-key-1234567890abcdefghijklmnopq');
+
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          choices: [{ message: { content: 'Long Message Discussion' } }]
+        })
+      });
+
+      const longMsg = 'a'.repeat(1000);
+      await AutoTitle.generateTitle(longMsg, 'reply', 'sess-long');
+
+      const callBody = JSON.parse(global.fetch.mock.calls[0][1].body);
+      const userContent = callBody.messages[1].content;
+      expect(userContent.length).toBeLessThan(1020);
+    });
+  });
+
+  describe('onMessageComplete', () => {
+    test('does nothing when disabled', () => {
+      AutoTitle.setEnabled(false);
+      global.fetch = jest.fn();
+      AutoTitle.onMessageComplete();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    test('does nothing when no messages', () => {
+      global.fetch = jest.fn();
+      AutoTitle.onMessageComplete();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    test('does nothing when more than one exchange', () => {
+      ConversationManager.addMessage('user', 'first');
+      ConversationManager.addMessage('assistant', 'reply 1');
+      ConversationManager.addMessage('user', 'second');
+      ConversationManager.addMessage('assistant', 'reply 2');
+      global.fetch = jest.fn();
+      AutoTitle.onMessageComplete();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    test('does nothing when no active session ID', () => {
+      ConversationManager.addMessage('user', 'hello');
+      ConversationManager.addMessage('assistant', 'hi');
+      global.fetch = jest.fn();
+      AutoTitle.onMessageComplete();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    test('triggers title generation on first exchange with active session', async () => {
+      ApiKeyManager.setOpenAIKey('sk-test-key-1234567890abcdefghijklmnopq');
+      const sessions = [{
+        id: 'sess-hook', name: 'hello', messages: [],
+        messageCount: 1, preview: '',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
+      }];
+      localStorage.setItem('agenticchat_sessions', JSON.stringify(sessions));
+      localStorage.setItem('agenticchat_active_session', 'sess-hook');
+
+      ConversationManager.addMessage('user', 'What is Python?');
+      ConversationManager.addMessage('assistant', 'Python is a programming language.');
+
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          choices: [{ message: { content: 'Introduction to Python' } }]
+        })
+      });
+
+      AutoTitle.onMessageComplete();
+
+      await new Promise(r => setTimeout(r, 50));
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      const updated = JSON.parse(localStorage.getItem('agenticchat_sessions'));
+      expect(updated[0].name).toBe('Introduction to Python');
+    });
+  });
+});

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -313,7 +313,8 @@ function loadApp() {
     'MessageScheduler',
     'SmartRetry',
     'UsageHeatmap',
-    'ContextWindowMeter'
+    'ContextWindowMeter',
+    'AutoTitle'
   ];
 
   for (const mod of modules) {


### PR DESCRIPTION
After the first user/assistant exchange, AutoTitle sends a lightweight gpt-4o-mini request (20 max tokens) to generate a concise 3-7 word title and updates the session name automatically.

**Key features:**
- Enabled by default, toggle via AutoTitle.setEnabled(bool)
- Only fires when auto-save is active
- Deduplication via titled session ID tracking (capped at 200)
- Cleans API responses (strips quotes, trailing periods)
- Graceful failure — never blocks chat flow
- 29 new tests covering all paths