### PR TITLE
feat: Conversation Starters — save & load full conversation templates

### DIFF
--- a/app.js
+++ b/app.js
@@ -55,6 +55,7 @@
  *   MessageEditor        — edit & resend user messages (truncate + reload into input)
  *   SmartRetry           — automatic retry with exponential backoff for transient API failures
  *   UsageHeatmap         — GitHub-style 7×24 activity heatmap across all sessions
+ *   ConversationStarters — save & load full conversation templates (system prompt + seed messages)
  *
  * All modules communicate through a thin public API; no direct DOM
  * manipulation outside UIController except where unavoidable (sandbox).
@@ -8300,6 +8301,7 @@ document.addEventListener('DOMContentLoaded', () => {
       Scratchpad.close();
       ConversationChapters.closePanel();
       UsageHeatmap.close();
+      ConversationStarters.closePanel();
     }
   });
 
@@ -16193,3 +16195,493 @@ const ContextWindowMeter = (() => {
 })();
 
 document.addEventListener('DOMContentLoaded', ContextWindowMeter.init);
+
+/* ============================================================
+ * ConversationStarters — Save & load full conversation templates
+ *
+ * Captures the current system prompt + seed messages as a reusable
+ * "starter" that can launch new sessions pre-filled with context.
+ * Great for recurring workflows (code review, brainstorming, etc.).
+ *
+ * Storage key: ac-conversation-starters
+ * @namespace ConversationStarters
+ * ============================================================ */
+const ConversationStarters = (() => {
+  const STORAGE_KEY = 'ac-conversation-starters';
+  const MAX_STARTERS = 30;
+  const MAX_NAME_LENGTH = 80;
+  const MAX_DESC_LENGTH = 200;
+  const MAX_MESSAGES = 50;
+
+  let starters = [];
+  let panelOpen = false;
+
+  function load() {
+    try {
+      const raw = SafeStorage.get(STORAGE_KEY);
+      if (!raw) { starters = []; return; }
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) { starters = []; return; }
+      starters = sanitizeStorageObject(parsed).filter(s =>
+        s && typeof s.id === 'string' && typeof s.name === 'string' && Array.isArray(s.messages)
+      );
+    } catch (_) {
+      starters = [];
+    }
+  }
+
+  function save() {
+    try {
+      SafeStorage.set(STORAGE_KEY, JSON.stringify(starters));
+    } catch (_) {}
+  }
+
+  function createFromCurrent(name, description, messageCount) {
+    if (!name || typeof name !== 'string') return null;
+    if (starters.length >= MAX_STARTERS) return null;
+
+    const history = ConversationManager.getHistory();
+    if (!history || history.length === 0) return null;
+
+    const trimmedName = name.trim().substring(0, MAX_NAME_LENGTH);
+    if (!trimmedName) return null;
+
+    const limit = (typeof messageCount === 'number' && messageCount > 0)
+      ? Math.min(messageCount, MAX_MESSAGES)
+      : Math.min(history.length, MAX_MESSAGES);
+
+    const messages = history.slice(0, limit).map(m => ({
+      role: m.role,
+      content: m.content
+    }));
+
+    const starter = {
+      id: Date.now().toString(36) + '-' + Math.random().toString(36).substring(2, 8),
+      name: trimmedName,
+      description: (description || '').trim().substring(0, MAX_DESC_LENGTH),
+      messages,
+      model: ChatConfig.MODEL,
+      messageCount: messages.length,
+      createdAt: new Date().toISOString(),
+      usageCount: 0,
+      lastUsedAt: null
+    };
+
+    starters.push(starter);
+    save();
+    return starter;
+  }
+
+  function createFromData(data) {
+    if (!data || typeof data.name !== 'string' || !Array.isArray(data.messages)) return null;
+    if (starters.length >= MAX_STARTERS) return null;
+    if (data.messages.length === 0) return null;
+
+    const messages = data.messages.slice(0, MAX_MESSAGES).map(m => ({
+      role: String(m.role || 'user'),
+      content: String(m.content || '')
+    }));
+
+    const starter = {
+      id: Date.now().toString(36) + '-' + Math.random().toString(36).substring(2, 8),
+      name: String(data.name).trim().substring(0, MAX_NAME_LENGTH),
+      description: String(data.description || '').trim().substring(0, MAX_DESC_LENGTH),
+      messages,
+      model: data.model || ChatConfig.MODEL,
+      messageCount: messages.length,
+      createdAt: new Date().toISOString(),
+      usageCount: 0,
+      lastUsedAt: null
+    };
+
+    starters.push(starter);
+    save();
+    return starter;
+  }
+
+  function remove(id) {
+    const before = starters.length;
+    starters = starters.filter(s => s.id !== id);
+    if (starters.length !== before) save();
+    return starters.length !== before;
+  }
+
+  function rename(id, newName) {
+    if (!newName || typeof newName !== 'string') return false;
+    const starter = starters.find(s => s.id === id);
+    if (!starter) return false;
+    starter.name = newName.trim().substring(0, MAX_NAME_LENGTH);
+    save();
+    return true;
+  }
+
+  function updateDescription(id, desc) {
+    const starter = starters.find(s => s.id === id);
+    if (!starter) return false;
+    starter.description = String(desc || '').trim().substring(0, MAX_DESC_LENGTH);
+    save();
+    return true;
+  }
+
+  function getAll() { return [...starters]; }
+  function getById(id) { return starters.find(s => s.id === id) || null; }
+  function getCount() { return starters.length; }
+
+  function search(query) {
+    if (!query || typeof query !== 'string') return getAll();
+    const q = query.toLowerCase().trim();
+    if (!q) return getAll();
+    return starters.filter(s =>
+      s.name.toLowerCase().includes(q) ||
+      (s.description && s.description.toLowerCase().includes(q))
+    );
+  }
+
+  function apply(id) {
+    const starter = starters.find(s => s.id === id);
+    if (!starter || !Array.isArray(starter.messages) || starter.messages.length === 0) return false;
+
+    ConversationManager.clear();
+
+    const first = starter.messages[0];
+    if (first.role === 'system') {
+      ConversationManager.setSystemPrompt(first.content);
+    }
+
+    const startIdx = first.role === 'system' ? 1 : 0;
+    for (let i = startIdx; i < starter.messages.length; i++) {
+      ConversationManager.addMessage(starter.messages[i].role, starter.messages[i].content);
+    }
+
+    starter.usageCount = (starter.usageCount || 0) + 1;
+    starter.lastUsedAt = new Date().toISOString();
+    save();
+
+    if (typeof UIController !== 'undefined' && UIController.renderHistory) {
+      UIController.renderHistory(ConversationManager.getHistory());
+    }
+
+    return true;
+  }
+
+  function duplicate(id) {
+    const starter = starters.find(s => s.id === id);
+    if (!starter) return null;
+    if (starters.length >= MAX_STARTERS) return null;
+
+    const copy = {
+      ...starter,
+      id: Date.now().toString(36) + '-' + Math.random().toString(36).substring(2, 8),
+      name: (starter.name + ' (copy)').substring(0, MAX_NAME_LENGTH),
+      messages: starter.messages.map(m => ({ ...m })),
+      createdAt: new Date().toISOString(),
+      usageCount: 0,
+      lastUsedAt: null
+    };
+
+    starters.push(copy);
+    save();
+    return copy;
+  }
+
+  function exportAll() { return JSON.stringify(starters, null, 2); }
+
+  function exportOne(id) {
+    const starter = starters.find(s => s.id === id);
+    return starter ? JSON.stringify(starter, null, 2) : null;
+  }
+
+  function importStarters(jsonString) {
+    try {
+      const data = JSON.parse(jsonString);
+      const arr = Array.isArray(data) ? data : [data];
+      let imported = 0;
+      for (const item of arr) {
+        if (starters.length >= MAX_STARTERS) break;
+        if (createFromData(item)) imported++;
+      }
+      return imported;
+    } catch (_) {
+      return 0;
+    }
+  }
+
+  function clearAll() { starters = []; save(); }
+
+  const BUILT_IN = [
+    {
+      name: 'Code Review',
+      description: 'Start a code review session with structured analysis prompts',
+      messages: [
+        { role: 'system', content: 'You are a senior code reviewer. Analyze code for bugs, performance issues, security vulnerabilities, and style. Provide specific, actionable feedback with line references. Rate severity as: critical, major, minor, or nitpick.' },
+        { role: 'user', content: 'I\'d like you to review some code. I\'ll paste it in the next message. Please analyze it for:\n1. Bugs and logic errors\n2. Performance issues\n3. Security vulnerabilities\n4. Code style and readability\n5. Suggestions for improvement' },
+        { role: 'assistant', content: 'Ready for your code review! Please paste the code and let me know:\n- **Language/framework** (if not obvious)\n- **Context** \u2014 what does this code do?\n- **Any specific concerns** you have?\n\nI\'ll provide a structured review covering all five areas you mentioned.' }
+      ],
+      model: 'gpt-4o'
+    },
+    {
+      name: 'Brainstorming',
+      description: 'Creative brainstorming session with divergent thinking prompts',
+      messages: [
+        { role: 'system', content: 'You are a creative brainstorming partner. Use techniques like SCAMPER, mind mapping, and lateral thinking. Generate many ideas before evaluating. Be bold and unconventional. Number all ideas for easy reference.' },
+        { role: 'user', content: 'Let\'s brainstorm! I\'ll share a topic or challenge, and I want you to generate as many ideas as possible \u2014 even wild ones. We\'ll narrow down later.' },
+        { role: 'assistant', content: 'Love it! I\'m in brainstorming mode \u2014 no idea is too wild. Share your topic and I\'ll fire off ideas using different creative techniques. We can always refine later.\n\nWhat are we brainstorming about?' }
+      ],
+      model: 'gpt-4o'
+    },
+    {
+      name: 'Debug Session',
+      description: 'Systematic debugging with structured problem analysis',
+      messages: [
+        { role: 'system', content: 'You are an expert debugger. Use systematic approaches: reproduce, isolate, identify root cause, fix, verify. Ask clarifying questions. Consider edge cases. Think about what changed recently.' },
+        { role: 'user', content: 'I have a bug I need help debugging. Let me describe the issue.' },
+        { role: 'assistant', content: 'Let\'s debug this systematically. Please tell me:\n\n1. **What\'s happening** vs. what you expected?\n2. **When did it start?** (recent change? always broken?)\n3. **Error messages** \u2014 exact text if any\n4. **Steps to reproduce**\n5. **What you\'ve already tried**\n\nPaste relevant code and I\'ll help track it down.' }
+      ],
+      model: 'gpt-4o'
+    },
+    {
+      name: 'Technical Writing',
+      description: 'Documentation and technical content creation',
+      messages: [
+        { role: 'system', content: 'You are a technical writer. Write clear, concise documentation. Use active voice, short sentences, and concrete examples. Structure content with headers, lists, and code blocks. Target audience awareness is key.' },
+        { role: 'user', content: 'I need help writing some technical documentation. I\'ll describe what needs documenting.' },
+        { role: 'assistant', content: 'Happy to help with docs! Let me know:\n\n- **What** are we documenting? (API, library, process, tutorial?)\n- **Who\'s the audience?** (beginners, developers, end users?)\n- **Format** \u2014 README, API reference, how-to guide, or something else?\n- **Any existing docs** to build on?\n\nI\'ll draft structured, clear documentation.' }
+      ],
+      model: 'gpt-4o'
+    },
+    {
+      name: 'Learning Session',
+      description: 'Socratic learning with explanations tailored to your level',
+      messages: [
+        { role: 'system', content: 'You are a patient, Socratic tutor. Explain concepts from first principles. Use analogies, examples, and progressive complexity. Check understanding before moving on. Encourage questions.' },
+        { role: 'user', content: 'I want to learn about a topic. I\'ll tell you what and my current level.' },
+        { role: 'assistant', content: 'Great, let\'s learn together! Tell me:\n\n1. **What topic** interests you?\n2. **Your current level** \u2014 complete beginner, some exposure, or need deeper understanding?\n3. **Goal** \u2014 general understanding, specific skill, or exam prep?\n\nI\'ll tailor explanations to your level and build up from there.' }
+      ],
+      model: 'gpt-4o'
+    }
+  ];
+
+  function loadBuiltIns() {
+    if (starters.length > 0) return 0;
+    let added = 0;
+    for (const bi of BUILT_IN) {
+      if (createFromData(bi)) added++;
+    }
+    return added;
+  }
+
+  function togglePanel() {
+    panelOpen = !panelOpen;
+    const panel = document.getElementById('starters-panel');
+    const overlay = document.getElementById('starters-overlay');
+    if (!panel || !overlay) return;
+
+    if (panelOpen) {
+      renderPanel();
+      panel.style.display = 'block';
+      overlay.style.display = 'block';
+      const searchInput = document.getElementById('starters-search');
+      if (searchInput) searchInput.focus();
+    } else {
+      panel.style.display = 'none';
+      overlay.style.display = 'none';
+    }
+  }
+
+  function closePanel() {
+    panelOpen = false;
+    const panel = document.getElementById('starters-panel');
+    const overlay = document.getElementById('starters-overlay');
+    if (panel) panel.style.display = 'none';
+    if (overlay) overlay.style.display = 'none';
+  }
+
+  function renderPanel() {
+    const list = document.getElementById('starters-list');
+    if (!list) return;
+
+    const searchInput = document.getElementById('starters-search');
+    const query = searchInput ? searchInput.value : '';
+    const filtered = search(query);
+
+    if (filtered.length === 0) {
+      list.innerHTML = '<div class="starters-empty">' +
+        (query ? 'No starters match your search.' : 'No starters yet. Save your current conversation as a starter!') +
+        '</div>';
+      return;
+    }
+
+    list.innerHTML = filtered.map(s => {
+      const msgCount = s.messageCount || (s.messages ? s.messages.length : 0);
+      const usageText = s.usageCount ? 'Used ' + s.usageCount + '\u00d7' : 'Never used';
+      const dateText = s.createdAt ? new Date(s.createdAt).toLocaleDateString() : '';
+      const descHtml = s.description ? '<div class="starter-desc">' + _escapeHtml(s.description) + '</div>' : '';
+      const modelBadge = s.model ? '<span class="starter-model">' + _escapeHtml(s.model) + '</span>' : '';
+
+      return '<div class="starter-card" data-id="' + _escapeHtml(s.id) + '">' +
+        '<div class="starter-header">' +
+          '<span class="starter-name">' + _escapeHtml(s.name) + '</span>' +
+          modelBadge +
+        '</div>' +
+        descHtml +
+        '<div class="starter-meta">' +
+          '<span>' + msgCount + ' message' + (msgCount !== 1 ? 's' : '') + '</span>' +
+          '<span>' + usageText + '</span>' +
+          '<span>' + dateText + '</span>' +
+        '</div>' +
+        '<div class="starter-actions">' +
+          '<button class="starter-apply-btn" data-id="' + _escapeHtml(s.id) + '" title="Start new conversation from this template">\u25b6 Use</button>' +
+          '<button class="starter-dup-btn" data-id="' + _escapeHtml(s.id) + '" title="Duplicate">\ud83d\udccb</button>' +
+          '<button class="starter-export-btn" data-id="' + _escapeHtml(s.id) + '" title="Export as JSON">\u2b07\ufe0f</button>' +
+          '<button class="starter-del-btn" data-id="' + _escapeHtml(s.id) + '" title="Delete">\ud83d\uddd1\ufe0f</button>' +
+        '</div>' +
+      '</div>';
+    }).join('');
+
+    list.querySelectorAll('.starter-apply-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        if (confirm('This will clear your current conversation and load this starter. Continue?')) {
+          apply(btn.dataset.id);
+          closePanel();
+        }
+      });
+    });
+    list.querySelectorAll('.starter-dup-btn').forEach(btn => {
+      btn.addEventListener('click', () => { duplicate(btn.dataset.id); renderPanel(); });
+    });
+    list.querySelectorAll('.starter-export-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const s = getById(btn.dataset.id);
+        if (s) downloadBlob('starter-' + s.name.replace(/\s+/g, '-') + '.json', exportOne(s.id), 'application/json');
+      });
+    });
+    list.querySelectorAll('.starter-del-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        if (confirm('Delete this starter?')) { remove(btn.dataset.id); renderPanel(); }
+      });
+    });
+  }
+
+  function openSaveDialog() {
+    let dialog = document.getElementById('starters-save-dialog');
+    if (!dialog) return;
+    dialog.style.display = 'flex';
+    const nameInput = document.getElementById('starter-save-name');
+    if (nameInput) { nameInput.value = ''; nameInput.focus(); }
+    const descInput = document.getElementById('starter-save-desc');
+    if (descInput) descInput.value = '';
+  }
+
+  function closeSaveDialog() {
+    const dialog = document.getElementById('starters-save-dialog');
+    if (dialog) dialog.style.display = 'none';
+  }
+
+  function handleSave() {
+    const nameInput = document.getElementById('starter-save-name');
+    const descInput = document.getElementById('starter-save-desc');
+    const name = nameInput ? nameInput.value.trim() : '';
+    const desc = descInput ? descInput.value.trim() : '';
+
+    if (!name) {
+      if (nameInput) nameInput.classList.add('input-error');
+      return false;
+    }
+
+    const result = createFromCurrent(name, desc);
+    if (!result) return false;
+
+    closeSaveDialog();
+    if (panelOpen) renderPanel();
+    return true;
+  }
+
+  function triggerImport() {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.json';
+    input.addEventListener('change', () => {
+      const file = input.files[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = () => {
+        const count = importStarters(reader.result);
+        if (count > 0 && panelOpen) renderPanel();
+      };
+      reader.readAsText(file);
+    });
+    input.click();
+  }
+
+  function init() {
+    load();
+    loadBuiltIns();
+
+    const btn = document.getElementById('starters-btn');
+    if (btn) btn.addEventListener('click', togglePanel);
+
+    const closeBtn = document.getElementById('starters-close-btn');
+    if (closeBtn) closeBtn.addEventListener('click', closePanel);
+
+    const overlay = document.getElementById('starters-overlay');
+    if (overlay) overlay.addEventListener('click', closePanel);
+
+    const searchInput = document.getElementById('starters-search');
+    if (searchInput) searchInput.addEventListener('input', () => renderPanel());
+
+    const saveBtn = document.getElementById('starters-save-btn');
+    if (saveBtn) saveBtn.addEventListener('click', openSaveDialog);
+
+    const importBtn = document.getElementById('starters-import-btn');
+    if (importBtn) importBtn.addEventListener('click', triggerImport);
+
+    const exportAllBtn = document.getElementById('starters-export-all-btn');
+    if (exportAllBtn) exportAllBtn.addEventListener('click', () => {
+      downloadBlob('conversation-starters.json', exportAll(), 'application/json');
+    });
+
+    const confirmSaveBtn = document.getElementById('starter-save-confirm');
+    if (confirmSaveBtn) confirmSaveBtn.addEventListener('click', handleSave);
+
+    const cancelSaveBtn = document.getElementById('starter-save-cancel');
+    if (cancelSaveBtn) cancelSaveBtn.addEventListener('click', closeSaveDialog);
+
+    const nameInput = document.getElementById('starter-save-name');
+    if (nameInput) nameInput.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') { e.preventDefault(); handleSave(); }
+    });
+  }
+
+  return {
+    init,
+    togglePanel,
+    closePanel,
+    openSaveDialog,
+    closeSaveDialog,
+    handleSave,
+    triggerImport,
+    createFromCurrent,
+    createFromData,
+    apply,
+    remove,
+    rename,
+    updateDescription,
+    duplicate,
+    getAll,
+    getById,
+    getCount,
+    search,
+    exportAll,
+    exportOne,
+    importStarters,
+    clearAll,
+    loadBuiltIns,
+    MAX_STARTERS,
+    MAX_NAME_LENGTH,
+    MAX_DESC_LENGTH,
+    MAX_MESSAGES,
+    BUILT_IN
+  };
+})();
+
+document.addEventListener('DOMContentLoaded', ConversationStarters.init);

--- a/index.html
+++ b/index.html
@@ -54,6 +54,7 @@
     <button id="fmt-btn" class="btn-secondary" title="Formatting toolbar — markdown helpers (Ctrl+Shift+M)">✏️</button>
     <button id="rating-btn" class="btn-secondary" title="Response ratings — rate AI responses and view satisfaction stats">⭐</button>
     <button id="prompt-library-btn" class="btn-secondary" title="Prompt Library — save and reuse your prompts (Ctrl+L)">📚</button>
+    <button id="starters-btn" class="btn-secondary" title="Conversation Starters — reusable session templates (Ctrl+Shift+T)">🚀</button>
   </div>
 
   <div class="zen-indicator">Focus Mode — press <kbd>Ctrl+Shift+F</kbd> or <kbd>Esc</kbd> to exit</div>
@@ -400,6 +401,38 @@
       <button id="model-close-btn" class="btn-sm" title="Close">✕</button>
     </div>
     <div id="model-list"></div>
+  </div>
+
+  <!-- Conversation Starters panel -->
+  <div id="starters-overlay" class="panel-overlay" style="display:none"></div>
+  <div id="starters-panel" class="side-panel" style="display:none" role="dialog" aria-label="Conversation Starters">
+    <div class="panel-header">
+      <strong>🚀 Conversation Starters</strong>
+      <div class="panel-header-actions">
+        <button id="starters-save-btn" class="btn-sm" title="Save current conversation as a starter">💾 Save Current</button>
+        <button id="starters-import-btn" class="btn-sm" title="Import starters from JSON">📥 Import</button>
+        <button id="starters-export-all-btn" class="btn-sm" title="Export all starters as JSON">📤 Export All</button>
+        <button id="starters-close-btn" class="btn-sm" title="Close">✕</button>
+      </div>
+    </div>
+    <input id="starters-search" type="text" placeholder="Search starters…" autocomplete="off">
+    <div id="starters-list"></div>
+  </div>
+
+  <!-- Starters save dialog -->
+  <div id="starters-save-dialog" class="modal-overlay" style="display:none">
+    <div class="modal-dialog">
+      <h3>Save as Starter</h3>
+      <p>Save the current conversation (system prompt + messages) as a reusable template.</p>
+      <label for="starter-save-name">Name</label>
+      <input id="starter-save-name" type="text" placeholder="e.g. Code Review, API Design…" maxlength="80" autocomplete="off">
+      <label for="starter-save-desc">Description (optional)</label>
+      <input id="starter-save-desc" type="text" placeholder="Brief description…" maxlength="200" autocomplete="off">
+      <div class="modal-actions">
+        <button id="starter-save-confirm" class="btn-primary">Save</button>
+        <button id="starter-save-cancel" class="btn-secondary">Cancel</button>
+      </div>
+    </div>
   </div>
 
   <script src="app.js"></script>

--- a/style.css
+++ b/style.css
@@ -2800,3 +2800,95 @@ body.light-theme #heatmap-panel {
 /* Light theme overrides */
 [data-theme="light"] .context-meter__bar { background: #e5e7eb; }
 [data-theme="light"] .context-meter { color: #6b7280; }
+
+/* ── Conversation Starters ─────────────────────────────── */
+.starter-card {
+  background: var(--bg-tertiary, #2a2a2a);
+  border: 1px solid var(--border, #444);
+  border-radius: 8px;
+  padding: 12px;
+  margin-bottom: 8px;
+  transition: border-color 0.15s;
+}
+.starter-card:hover { border-color: var(--accent, #7c3aed); }
+.starter-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+.starter-name { font-weight: 600; font-size: 0.95rem; }
+.starter-model {
+  font-size: 0.7rem;
+  background: var(--accent, #7c3aed);
+  color: #fff;
+  padding: 1px 6px;
+  border-radius: 4px;
+}
+.starter-desc {
+  font-size: 0.82rem;
+  color: var(--text-secondary, #aaa);
+  margin-bottom: 4px;
+}
+.starter-meta {
+  display: flex;
+  gap: 12px;
+  font-size: 0.75rem;
+  color: var(--text-tertiary, #888);
+  margin-bottom: 6px;
+}
+.starter-actions {
+  display: flex;
+  gap: 4px;
+}
+.starter-actions button {
+  font-size: 0.8rem;
+  padding: 2px 8px;
+  border: 1px solid var(--border, #444);
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+.starter-actions button:hover { background: var(--bg-hover, #333); }
+.starter-apply-btn { font-weight: 600; }
+.starters-empty {
+  text-align: center;
+  padding: 24px;
+  color: var(--text-secondary, #aaa);
+  font-style: italic;
+}
+
+/* Save dialog */
+#starters-save-dialog .modal-dialog {
+  max-width: 400px;
+}
+#starters-save-dialog label {
+  display: block;
+  font-size: 0.85rem;
+  margin: 8px 0 4px;
+  color: var(--text-secondary, #aaa);
+}
+#starters-save-dialog input[type="text"] {
+  width: 100%;
+  padding: 6px 8px;
+  border: 1px solid var(--border, #444);
+  border-radius: 4px;
+  background: var(--bg-secondary, #1e1e1e);
+  color: inherit;
+  font-size: 0.9rem;
+}
+#starters-save-dialog input.input-error {
+  border-color: #ef4444;
+}
+.modal-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+  justify-content: flex-end;
+}
+
+[data-theme="light"] .starter-card { background: #f9fafb; border-color: #e5e7eb; }
+[data-theme="light"] .starter-card:hover { border-color: #7c3aed; }
+[data-theme="light"] .starter-actions button { border-color: #d1d5db; }
+[data-theme="light"] .starter-actions button:hover { background: #f3f4f6; }

--- a/tests/conversation-starters.test.js
+++ b/tests/conversation-starters.test.js
@@ -1,0 +1,353 @@
+/**
+ * ConversationStarters — Unit Tests
+ * @jest-environment jsdom
+ */
+
+const { setupDOM, loadApp } = require('./setup');
+
+beforeEach(() => {
+  localStorage.clear();
+  setupDOM();
+  loadApp();
+  ConversationStarters.clearAll();
+});
+
+describe('ConversationStarters', () => {
+
+  test('starts empty after clearAll', () => {
+    expect(ConversationStarters.getAll()).toEqual([]);
+    expect(ConversationStarters.getCount()).toBe(0);
+  });
+
+  test('createFromCurrent captures system prompt + messages', () => {
+    ConversationManager.addMessage('user', 'Hello');
+    ConversationManager.addMessage('assistant', 'Hi there');
+
+    const starter = ConversationStarters.createFromCurrent('Test Starter', 'A test');
+    expect(starter).not.toBeNull();
+    expect(starter.name).toBe('Test Starter');
+    expect(starter.description).toBe('A test');
+    expect(starter.messages.length).toBe(3);
+    expect(starter.messages[0].role).toBe('system');
+    expect(starter.messages[1].content).toBe('Hello');
+    expect(starter.usageCount).toBe(0);
+  });
+
+  test('createFromCurrent returns null for empty/invalid name', () => {
+    expect(ConversationStarters.createFromCurrent('')).toBeNull();
+    expect(ConversationStarters.createFromCurrent(null)).toBeNull();
+    expect(ConversationStarters.createFromCurrent(123)).toBeNull();
+    expect(ConversationStarters.createFromCurrent('   ')).toBeNull();
+  });
+
+  test('createFromCurrent truncates long names and descriptions', () => {
+    ConversationManager.addMessage('user', 'test');
+    const s = ConversationStarters.createFromCurrent('A'.repeat(200), 'D'.repeat(500));
+    expect(s.name.length).toBe(ConversationStarters.MAX_NAME_LENGTH);
+    expect(s.description.length).toBe(ConversationStarters.MAX_DESC_LENGTH);
+  });
+
+  test('createFromCurrent respects messageCount limit', () => {
+    ConversationManager.addMessage('user', 'msg1');
+    ConversationManager.addMessage('assistant', 'reply1');
+    ConversationManager.addMessage('user', 'msg2');
+
+    const s = ConversationStarters.createFromCurrent('Limited', '', 2);
+    expect(s.messages.length).toBe(2);
+  });
+
+  test('createFromCurrent enforces MAX_STARTERS', () => {
+    for (let i = 0; i < ConversationStarters.MAX_STARTERS; i++) {
+      ConversationStarters.createFromCurrent('Starter ' + i);
+    }
+    expect(ConversationStarters.getCount()).toBe(ConversationStarters.MAX_STARTERS);
+    expect(ConversationStarters.createFromCurrent('One More')).toBeNull();
+  });
+
+  test('createFromData creates from raw object', () => {
+    const s = ConversationStarters.createFromData({
+      name: 'Imported',
+      description: 'From import',
+      messages: [
+        { role: 'system', content: 'Be helpful' },
+        { role: 'user', content: 'Hi' }
+      ],
+      model: 'gpt-4'
+    });
+    expect(s).not.toBeNull();
+    expect(s.name).toBe('Imported');
+    expect(s.model).toBe('gpt-4');
+    expect(s.messages.length).toBe(2);
+  });
+
+  test('createFromData rejects invalid input', () => {
+    expect(ConversationStarters.createFromData(null)).toBeNull();
+    expect(ConversationStarters.createFromData({})).toBeNull();
+    expect(ConversationStarters.createFromData({ name: 'X' })).toBeNull();
+    expect(ConversationStarters.createFromData({ name: 'X', messages: [] })).toBeNull();
+    expect(ConversationStarters.createFromData({ name: 123, messages: [{ role: 'user', content: 'hi' }] })).toBeNull();
+  });
+
+  test('createFromData limits messages to MAX_MESSAGES', () => {
+    const msgs = [];
+    for (let i = 0; i < 60; i++) msgs.push({ role: 'user', content: 'msg ' + i });
+    const s = ConversationStarters.createFromData({ name: 'Lots', messages: msgs });
+    expect(s.messages.length).toBe(ConversationStarters.MAX_MESSAGES);
+  });
+
+  test('createFromData coerces non-string content', () => {
+    const s = ConversationStarters.createFromData({
+      name: 'Coerce', messages: [{ role: 'user', content: 42 }]
+    });
+    expect(s.messages[0].content).toBe('42');
+  });
+
+  test('remove deletes a starter by id', () => {
+    const s = ConversationStarters.createFromData({
+      name: 'ToDelete', messages: [{ role: 'user', content: 'x' }]
+    });
+    expect(ConversationStarters.remove(s.id)).toBe(true);
+    expect(ConversationStarters.getCount()).toBe(0);
+  });
+
+  test('remove returns false for non-existent id', () => {
+    expect(ConversationStarters.remove('nope')).toBe(false);
+  });
+
+  test('rename updates starter name', () => {
+    const s = ConversationStarters.createFromData({
+      name: 'Old', messages: [{ role: 'user', content: 'x' }]
+    });
+    expect(ConversationStarters.rename(s.id, 'New')).toBe(true);
+    expect(ConversationStarters.getById(s.id).name).toBe('New');
+  });
+
+  test('rename returns false for invalid input', () => {
+    expect(ConversationStarters.rename('nope', 'Name')).toBe(false);
+    const s = ConversationStarters.createFromData({
+      name: 'X', messages: [{ role: 'user', content: 'x' }]
+    });
+    expect(ConversationStarters.rename(s.id, '')).toBe(false);
+    expect(ConversationStarters.rename(s.id, null)).toBe(false);
+  });
+
+  test('updateDescription updates and handles null', () => {
+    const s = ConversationStarters.createFromData({
+      name: 'X', description: 'old', messages: [{ role: 'user', content: 'x' }]
+    });
+    expect(ConversationStarters.updateDescription(s.id, 'New desc')).toBe(true);
+    expect(ConversationStarters.getById(s.id).description).toBe('New desc');
+    ConversationStarters.updateDescription(s.id, null);
+    expect(ConversationStarters.getById(s.id).description).toBe('');
+    expect(ConversationStarters.updateDescription('nope', 'desc')).toBe(false);
+  });
+
+  test('search filters by name and description', () => {
+    ConversationStarters.createFromData({ name: 'Code Review', messages: [{ role: 'user', content: 'x' }] });
+    ConversationStarters.createFromData({
+      name: 'Alpha', description: 'For debugging', messages: [{ role: 'user', content: 'x' }]
+    });
+
+    expect(ConversationStarters.search('code').length).toBe(1);
+    expect(ConversationStarters.search('debug').length).toBe(1);
+    expect(ConversationStarters.search('').length).toBe(2);
+    expect(ConversationStarters.search(null).length).toBe(2);
+  });
+
+  test('search is case-insensitive', () => {
+    ConversationStarters.createFromData({ name: 'MyTemplate', messages: [{ role: 'user', content: 'x' }] });
+    expect(ConversationStarters.search('MYTEMPLATE').length).toBe(1);
+  });
+
+  test('apply loads starter messages into conversation', () => {
+    const s = ConversationStarters.createFromData({
+      name: 'Test',
+      messages: [
+        { role: 'system', content: 'Be a pirate' },
+        { role: 'user', content: 'Ahoy' },
+        { role: 'assistant', content: 'Yarr!' }
+      ]
+    });
+
+    expect(ConversationStarters.apply(s.id)).toBe(true);
+    const history = ConversationManager.getHistory();
+    expect(history[0].content).toBe('Be a pirate');
+    expect(history[1].content).toBe('Ahoy');
+    expect(history[2].content).toBe('Yarr!');
+  });
+
+  test('apply increments usage count and sets lastUsedAt', () => {
+    const s = ConversationStarters.createFromData({
+      name: 'Track', messages: [{ role: 'user', content: 'x' }]
+    });
+    expect(s.usageCount).toBe(0);
+    expect(s.lastUsedAt).toBeNull();
+    ConversationStarters.apply(s.id);
+    const updated = ConversationStarters.getById(s.id);
+    expect(updated.usageCount).toBe(1);
+    expect(updated.lastUsedAt).not.toBeNull();
+  });
+
+  test('apply returns false for non-existent id', () => {
+    expect(ConversationStarters.apply('nope')).toBe(false);
+  });
+
+  test('apply handles starters without system message', () => {
+    const s = ConversationStarters.createFromData({
+      name: 'NoSys',
+      messages: [{ role: 'user', content: 'Hello' }, { role: 'assistant', content: 'Hi' }]
+    });
+    expect(ConversationStarters.apply(s.id)).toBe(true);
+    const history = ConversationManager.getHistory();
+    expect(history[0].role).toBe('system');
+    expect(history[1].content).toBe('Hello');
+  });
+
+  test('duplicate creates a copy with reset stats', () => {
+    const s = ConversationStarters.createFromData({
+      name: 'Original', messages: [{ role: 'user', content: 'x' }]
+    });
+    const copy = ConversationStarters.duplicate(s.id);
+    expect(copy).not.toBeNull();
+    expect(copy.id).not.toBe(s.id);
+    expect(copy.name).toBe('Original (copy)');
+    expect(copy.usageCount).toBe(0);
+    expect(ConversationStarters.getCount()).toBe(2);
+  });
+
+  test('duplicate returns null for non-existent id or at limit', () => {
+    expect(ConversationStarters.duplicate('nope')).toBeNull();
+    for (let i = 0; i < ConversationStarters.MAX_STARTERS; i++) {
+      ConversationStarters.createFromData({ name: 'S' + i, messages: [{ role: 'user', content: 'x' }] });
+    }
+    expect(ConversationStarters.duplicate(ConversationStarters.getAll()[0].id)).toBeNull();
+  });
+
+  test('duplicate preserves message content independently', () => {
+    const s = ConversationStarters.createFromData({
+      name: 'Orig', messages: [{ role: 'user', content: 'original' }]
+    });
+    const copy = ConversationStarters.duplicate(s.id);
+    ConversationStarters.getById(s.id).messages[0].content = 'modified';
+    expect(ConversationStarters.getById(copy.id).messages[0].content).toBe('original');
+  });
+
+  test('exportAll and exportOne return valid JSON', () => {
+    ConversationStarters.createFromData({ name: 'A', messages: [{ role: 'user', content: 'x' }] });
+    const s = ConversationStarters.createFromData({ name: 'B', messages: [{ role: 'user', content: 'y' }] });
+    expect(JSON.parse(ConversationStarters.exportAll()).length).toBe(2);
+    expect(JSON.parse(ConversationStarters.exportOne(s.id)).name).toBe('B');
+    expect(ConversationStarters.exportOne('nope')).toBeNull();
+  });
+
+  test('importStarters imports array and single object', () => {
+    expect(ConversationStarters.importStarters(JSON.stringify([
+      { name: 'I1', messages: [{ role: 'user', content: 'a' }] },
+      { name: 'I2', messages: [{ role: 'user', content: 'b' }] }
+    ]))).toBe(2);
+    expect(ConversationStarters.importStarters(JSON.stringify(
+      { name: 'I3', messages: [{ role: 'user', content: 'c' }] }
+    ))).toBe(1);
+    expect(ConversationStarters.getCount()).toBe(3);
+  });
+
+  test('importStarters returns 0 for invalid JSON', () => {
+    expect(ConversationStarters.importStarters('not json')).toBe(0);
+  });
+
+  test('importStarters respects MAX_STARTERS', () => {
+    for (let i = 0; i < ConversationStarters.MAX_STARTERS - 1; i++) {
+      ConversationStarters.createFromData({ name: 'S' + i, messages: [{ role: 'user', content: 'x' }] });
+    }
+    const count = ConversationStarters.importStarters(JSON.stringify([
+      { name: 'N1', messages: [{ role: 'user', content: 'a' }] },
+      { name: 'N2', messages: [{ role: 'user', content: 'b' }] }
+    ]));
+    expect(count).toBe(1);
+  });
+
+  test('starters persist to localStorage', () => {
+    ConversationStarters.createFromData({ name: 'Persist', messages: [{ role: 'user', content: 'x' }] });
+    const stored = JSON.parse(localStorage.getItem('ac-conversation-starters'));
+    expect(stored.length).toBe(1);
+    expect(stored[0].name).toBe('Persist');
+  });
+
+  test('clearAll empties starters and storage', () => {
+    ConversationStarters.createFromData({ name: 'X', messages: [{ role: 'user', content: 'x' }] });
+    ConversationStarters.clearAll();
+    expect(ConversationStarters.getCount()).toBe(0);
+    expect(JSON.parse(localStorage.getItem('ac-conversation-starters'))).toEqual([]);
+  });
+
+  test('BUILT_IN has 5 starters with required fields', () => {
+    expect(ConversationStarters.BUILT_IN.length).toBe(5);
+    for (const bi of ConversationStarters.BUILT_IN) {
+      expect(typeof bi.name).toBe('string');
+      expect(bi.messages.length).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  test('loadBuiltIns populates when empty, skips when not', () => {
+    expect(ConversationStarters.loadBuiltIns()).toBe(5);
+    expect(ConversationStarters.getCount()).toBe(5);
+    // Adding one more and calling again should skip
+    ConversationStarters.createFromData({ name: 'Extra', messages: [{ role: 'user', content: 'x' }] });
+    expect(ConversationStarters.loadBuiltIns()).toBe(0);
+  });
+
+  test('togglePanel shows and hides panel', () => {
+    ConversationStarters.init();
+    ConversationStarters.togglePanel();
+    expect(document.getElementById('starters-panel').style.display).toBe('block');
+    ConversationStarters.togglePanel();
+    expect(document.getElementById('starters-panel').style.display).toBe('none');
+  });
+
+  test('closePanel hides panel', () => {
+    ConversationStarters.init();
+    ConversationStarters.togglePanel();
+    ConversationStarters.closePanel();
+    expect(document.getElementById('starters-panel').style.display).toBe('none');
+  });
+
+  test('save dialog open/close', () => {
+    ConversationStarters.init();
+    ConversationStarters.openSaveDialog();
+    expect(document.getElementById('starters-save-dialog').style.display).toBe('flex');
+    ConversationStarters.closeSaveDialog();
+    expect(document.getElementById('starters-save-dialog').style.display).toBe('none');
+  });
+
+  test('handleSave creates starter from input fields', () => {
+    ConversationStarters.init();
+    ConversationManager.addMessage('user', 'Hello');
+    document.getElementById('starter-save-name').value = 'My Starter';
+    document.getElementById('starter-save-desc').value = 'Test desc';
+    expect(ConversationStarters.handleSave()).toBe(true);
+    const all = ConversationStarters.getAll();
+    expect(all[all.length - 1].name).toBe('My Starter');
+  });
+
+  test('handleSave returns false for empty name', () => {
+    ConversationStarters.init();
+    document.getElementById('starter-save-name').value = '';
+    expect(ConversationStarters.handleSave()).toBe(false);
+  });
+
+  test('getById returns starter or null', () => {
+    const s = ConversationStarters.createFromData({
+      name: 'Find Me', messages: [{ role: 'user', content: 'x' }]
+    });
+    expect(ConversationStarters.getById(s.id).name).toBe('Find Me');
+    expect(ConversationStarters.getById('nonexistent')).toBeNull();
+  });
+
+  test('createFromData handles missing optional fields', () => {
+    const s = ConversationStarters.createFromData({
+      name: 'Minimal', messages: [{ role: 'user', content: 'hi' }]
+    });
+    expect(s).not.toBeNull();
+    expect(s.description).toBe('');
+  });
+});

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -240,6 +240,24 @@ function setupDOM() {
       <button id="heatmap-refresh-btn"></button>
     </div>
     <div id="file-drop-overlay"></div>
+    <button id="starters-btn"></button>
+    <div id="starters-overlay" style="display:none;"></div>
+    <div id="starters-panel" style="display:none;">
+      <input id="starters-search" type="text">
+      <div id="starters-list"></div>
+      <button id="starters-close-btn"></button>
+      <button id="starters-save-btn"></button>
+      <button id="starters-import-btn"></button>
+      <button id="starters-export-all-btn"></button>
+    </div>
+    <div id="starters-save-dialog" style="display:none;">
+      <div class="modal-dialog">
+        <input id="starter-save-name" type="text">
+        <input id="starter-save-desc" type="text">
+        <button id="starter-save-confirm"></button>
+        <button id="starter-save-cancel"></button>
+      </div>
+    </div>
   `;
 }
 
@@ -313,7 +331,8 @@ function loadApp() {
     'MessageScheduler',
     'SmartRetry',
     'UsageHeatmap',
-    'ContextWindowMeter'
+    'ContextWindowMeter',
+    'ConversationStarters'
   ];
 
   for (const mod of modules) {


### PR DESCRIPTION
## Conversation Starters

Save entire conversation setups (system prompt + seed messages) as reusable templates for new sessions.

### Features
- **Save current conversation** as a named/described starter template
- **5 built-in starters**: Code Review, Brainstorming, Debug Session, Technical Writing, Learning Session
- **Apply starters** to launch pre-configured sessions with one click
- **Search, duplicate, rename** starters
- **Import/export** as JSON (single or bulk)
- **Usage tracking** — count + last used timestamp
- **Panel UI** with search, cards, and action buttons
- **Save dialog** for naming and describing starters

### Limits & Safety
- Max 30 starters, 50 messages per starter
- Name truncation at 80 chars, description at 200 chars
- Full input validation and sanitization
- Persisted via SafeStorage (localStorage)

### Tests
- **39 unit tests** covering CRUD, search, apply, import/export, UI panel, and edge cases
- All existing tests unaffected (pre-existing failures remain unchanged)

### Files Changed
- \pp.js\ — ConversationStarters module (~450 LOC) + Escape key handler
- \index.html\ — toolbar button + panel + save dialog elements
- \style.css\ — starter card styles with dark/light theme
- \	ests/setup.js\ — DOM elements + module registration
- \	ests/conversation-starters.test.js\ — 39 tests