### PR TITLE
feat: offline support with service worker + PWA (fixes #38)

### DIFF
--- a/app.js
+++ b/app.js
@@ -16193,3 +16193,86 @@ const ContextWindowMeter = (() => {
 })();
 
 document.addEventListener('DOMContentLoaded', ContextWindowMeter.init);
+
+/* ── Offline Detection & Service Worker Registration ───────────────── */
+const OfflineManager = (function () {
+  'use strict';
+
+  var banner = null;
+  var sendBtn = null;
+  var _wasOffline = false;
+
+  function init() {
+    banner = document.getElementById('offline-banner');
+    sendBtn = document.getElementById('send-btn');
+    var dismissBtn = document.getElementById('offline-dismiss');
+
+    if (dismissBtn) {
+      dismissBtn.addEventListener('click', function () {
+        if (banner) banner.style.display = 'none';
+      });
+    }
+
+    window.addEventListener('online', _onOnline);
+    window.addEventListener('offline', _onOffline);
+
+    /* Check initial state */
+    if (!navigator.onLine) {
+      _onOffline();
+    }
+
+    /* Register service worker */
+    _registerSW();
+  }
+
+  function _onOffline() {
+    _wasOffline = true;
+    if (banner) banner.style.display = '';
+    if (sendBtn) {
+      sendBtn.disabled = true;
+      sendBtn.title = 'Cannot send — you are offline';
+    }
+  }
+
+  function _onOnline() {
+    if (banner) banner.style.display = 'none';
+    if (sendBtn) {
+      sendBtn.disabled = false;
+      sendBtn.title = '';
+    }
+    if (_wasOffline) {
+      _wasOffline = false;
+      console.log('[OfflineManager] Connection restored');
+    }
+  }
+
+  function _registerSW() {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('/sw.js')
+        .then(function (reg) {
+          console.log('[SW] Registered, scope:', reg.scope);
+          reg.addEventListener('updatefound', function () {
+            var newWorker = reg.installing;
+            if (newWorker) {
+              newWorker.addEventListener('statechange', function () {
+                if (newWorker.state === 'activated') {
+                  console.log('[SW] New version activated');
+                }
+              });
+            }
+          });
+        })
+        .catch(function (err) {
+          console.warn('[SW] Registration failed:', err.message);
+        });
+    }
+  }
+
+  function isOffline() {
+    return !navigator.onLine;
+  }
+
+  return { init: init, isOffline: isOffline };
+})();
+
+document.addEventListener('DOMContentLoaded', OfflineManager.init);

--- a/index.html
+++ b/index.html
@@ -4,8 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="A lightweight browser-based chat interface that turns natural language prompts into executable JavaScript, powered by OpenAI GPT-4o.">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self'; connect-src https://api.openai.com; frame-src 'self'; img-src 'self' data:; object-src 'none'; worker-src 'none'; form-action 'self'; base-uri 'self'; frame-ancestors 'none';">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self'; connect-src https://api.openai.com; frame-src 'self'; img-src 'self' data:; object-src 'none'; worker-src 'self'; form-action 'self'; base-uri 'self'; frame-ancestors 'none';">
   <title>Agentic Chat</title>
+  <link rel="manifest" href="manifest.json">
+  <meta name="theme-color" content="#2196F3">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -17,6 +19,12 @@
       <button id="cross-tab-keep" class="btn-sm" title="Keep this tab's version">Keep mine</button>
       <button id="cross-tab-dismiss" class="btn-sm" title="Dismiss this warning">✕</button>
     </div>
+  </div>
+
+  <!-- Offline notification banner -->
+  <div id="offline-banner" class="offline-banner" style="display:none" role="alert" aria-live="assertive">
+    <span>📡 You are offline — browsing cached data. Sending messages requires connectivity.</span>
+    <button id="offline-dismiss" class="btn-sm" title="Dismiss">✕</button>
   </div>
 
   <h2>Agentic Chat</h2>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,16 @@
+{
+  "name": "Agentic Chat",
+  "short_name": "AgenticChat",
+  "description": "A lightweight browser-based chat interface powered by OpenAI GPT-4o",
+  "start_url": "/index.html",
+  "display": "standalone",
+  "background_color": "#1e1e1e",
+  "theme_color": "#2196F3",
+  "icons": [
+    {
+      "src": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='80' font-size='80'>💬</text></svg>",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/style.css
+++ b/style.css
@@ -1970,6 +1970,36 @@ html.light .fork-notification {
   background: rgba(255,255,255,0.35);
 }
 
+/* ---------- Offline Banner ---------- */
+.offline-banner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 10001;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 16px;
+  background: linear-gradient(135deg, #d97706, #b45309);
+  color: #fff;
+  font-size: 0.85rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  animation: slideDown 0.3s ease-out;
+}
+.offline-banner .btn-sm {
+  background: rgba(255,255,255,0.2);
+  border: 1px solid rgba(255,255,255,0.3);
+  color: #fff;
+  cursor: pointer;
+  padding: 3px 10px;
+  border-radius: 4px;
+  font-size: 0.8rem;
+}
+.offline-banner .btn-sm:hover {
+  background: rgba(255,255,255,0.35);
+}
+
 /* ---------- Global Session Search ---------- */
 #global-search-overlay {
   display: none;

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,68 @@
+/* Service Worker for Agentic Chat — offline app shell caching */
+'use strict';
+
+const CACHE_NAME = 'agenticchat-v1';
+const APP_SHELL = [
+  '/',
+  '/index.html',
+  '/app.js',
+  '/style.css'
+];
+
+/* Install: pre-cache app shell */
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME)
+      .then(cache => cache.addAll(APP_SHELL))
+      .then(() => self.skipWaiting())
+  );
+});
+
+/* Activate: clean up old caches */
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys()
+      .then(keys => Promise.all(
+        keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k))
+      ))
+      .then(() => self.clients.claim())
+  );
+});
+
+/* Fetch: cache-first for app shell, network-first for API calls */
+self.addEventListener('fetch', event => {
+  const url = new URL(event.request.url);
+
+  /* Network-only for OpenAI API and other external requests */
+  if (url.origin !== self.location.origin) {
+    return;
+  }
+
+  /* Cache-first for app shell assets */
+  event.respondWith(
+    caches.match(event.request)
+      .then(cached => {
+        if (cached) {
+          /* Return cached version, update cache in background */
+          const fetchPromise = fetch(event.request)
+            .then(response => {
+              if (response.ok) {
+                const clone = response.clone();
+                caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
+              }
+              return response;
+            })
+            .catch(() => cached);
+          return cached;
+        }
+        /* Not cached — try network, cache the result */
+        return fetch(event.request).then(response => {
+          if (response.ok) {
+            const clone = response.clone();
+            caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
+          }
+          return response;
+        });
+      })
+  );
+});

--- a/tests/offline.test.js
+++ b/tests/offline.test.js
@@ -1,0 +1,86 @@
+/**
+ * Tests for OfflineManager — offline detection, UI, and service worker registration
+ */
+
+const { setupDOM, loadApp } = require('./setup');
+
+beforeAll(() => {
+  setupDOM();
+  loadApp();
+});
+
+describe('OfflineManager', () => {
+  let banner, sendBtn;
+
+  beforeEach(() => {
+    banner = document.getElementById('offline-banner');
+    sendBtn = document.getElementById('send-btn');
+    // Reset state
+    banner.style.display = 'none';
+    sendBtn.disabled = false;
+    sendBtn.title = '';
+    // Default to online
+    Object.defineProperty(navigator, 'onLine', {
+      value: true,
+      writable: true,
+      configurable: true
+    });
+  });
+
+  test('OfflineManager is defined', () => {
+    expect(typeof OfflineManager).toBe('object');
+    expect(typeof OfflineManager.init).toBe('function');
+    expect(typeof OfflineManager.isOffline).toBe('function');
+  });
+
+  test('isOffline returns false when online', () => {
+    Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
+    expect(OfflineManager.isOffline()).toBe(false);
+  });
+
+  test('isOffline returns true when offline', () => {
+    Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+    expect(OfflineManager.isOffline()).toBe(true);
+  });
+
+  test('offline event shows banner and disables send button', () => {
+    OfflineManager.init();
+    window.dispatchEvent(new Event('offline'));
+    expect(banner.style.display).toBe('');
+    expect(sendBtn.disabled).toBe(true);
+    expect(sendBtn.title).toContain('offline');
+  });
+
+  test('online event hides banner and enables send button', () => {
+    OfflineManager.init();
+    // Go offline first
+    window.dispatchEvent(new Event('offline'));
+    expect(banner.style.display).toBe('');
+    // Go back online
+    window.dispatchEvent(new Event('online'));
+    expect(banner.style.display).toBe('none');
+    expect(sendBtn.disabled).toBe(false);
+  });
+
+  test('dismiss button hides banner', () => {
+    OfflineManager.init();
+    window.dispatchEvent(new Event('offline'));
+    expect(banner.style.display).toBe('');
+    const dismissBtn = document.getElementById('offline-dismiss');
+    dismissBtn.click();
+    expect(banner.style.display).toBe('none');
+  });
+
+  test('init shows banner when starting offline', () => {
+    Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+    OfflineManager.init();
+    expect(banner.style.display).toBe('');
+    expect(sendBtn.disabled).toBe(true);
+  });
+
+  test('init does not show banner when starting online', () => {
+    Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
+    OfflineManager.init();
+    expect(banner.style.display).toBe('none');
+  });
+});

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -10,6 +10,10 @@ const path = require('path');
 
 function setupDOM() {
   document.body.innerHTML = `
+    <div id="offline-banner" class="offline-banner" style="display:none" role="alert" aria-live="assertive">
+      <span>📡 You are offline — browsing cached data. Sending messages requires connectivity.</span>
+      <button id="offline-dismiss" class="btn-sm" title="Dismiss">✕</button>
+    </div>
     <h2>Agentic Chat</h2>
     <div class="toolbar" role="form" aria-label="API key entry"></div>
     <div class="toolbar" role="form" aria-label="Chat input">
@@ -313,7 +317,8 @@ function loadApp() {
     'MessageScheduler',
     'SmartRetry',
     'UsageHeatmap',
-    'ContextWindowMeter'
+    'ContextWindowMeter',
+    'OfflineManager'
   ];
 
   for (const mod of modules) {


### PR DESCRIPTION
Implements Phase 1 and Phase 2 of #38.

**Service Worker (sw.js):** Cache-first for app shell assets, network-only for OpenAI API, stale-while-revalidate background updates, versioned cache cleanup.

**PWA (manifest.json):** Install support with standalone display, dark theme.

**Offline UI (OfflineManager):** Amber banner on connectivity loss, send button disabled when offline, auto-restores on reconnect, dismissable.

**CSP fix:** \worker-src 'none'\ → \'self'\ to allow service worker registration.

8 new tests, all passing. No regressions.