### PR TITLE
perf: CSS containment + content-visibility for rendering optimization

### DIFF
--- a/style.css
+++ b/style.css
@@ -164,6 +164,10 @@ button:disabled {
 #chat-output {
   margin-bottom: 1rem;
   white-space: pre-wrap;
+  /* CSS containment: tells the browser that layout/paint changes
+     inside chat output don't affect anything outside, enabling
+     rendering optimizations (skip re-layout of ancestor elements). */
+  contain: content;
 }
 
 #console-output {
@@ -283,6 +287,10 @@ pre {
   flex: 1;
   overflow-y: auto;
   padding: 0.75rem;
+  /* CSS containment: isolate layout/paint recalculations to this
+     scrollable container — prevents full-page reflow when messages
+     are added, removed, or decorated. */
+  contain: strict;
 }
 
 .history-msg {
@@ -292,6 +300,12 @@ pre {
   font-size: 0.88rem;
   line-height: 1.45;
   word-break: break-word;
+  /* content-visibility: auto lets the browser skip rendering off-screen
+     messages entirely, dramatically reducing initial paint time for
+     long conversations (100+ messages). contain-intrinsic-size gives
+     the browser an estimated height for scroll calculations. */
+  content-visibility: auto;
+  contain-intrinsic-size: auto 80px;
 }
 
 .history-msg.user {
@@ -553,6 +567,7 @@ pre {
   flex: 1;
   overflow-y: auto;
   padding: 0.5rem 0.75rem;
+  contain: strict;
 }
 
 .snippet-card {
@@ -1044,6 +1059,7 @@ kbd {
   flex: 1;
   overflow-y: auto;
   padding: 0.5rem 0.75rem;
+  contain: strict;
 }
 
 .sessions-empty {
@@ -2066,6 +2082,7 @@ html.light .fork-notification {
   overflow-y: auto; flex: 1;
   padding: 0 18px 14px;
   max-height: 55vh;
+  contain: strict;
 }
 
 .gs-result-group {


### PR DESCRIPTION
Zero-cost CSS rendering hints for long conversations.

**CSS Containment** (\contain: content|strict\) on 5 scrollable containers:
- \#chat-output\, \#history-messages\, \#snippets-list\, \#sessions-list\, \#global-search-results\
- Tells the browser that layout/paint changes inside these containers don't affect anything outside
- Prevents full-page reflow when messages are added, removed, or decorated

**Content Visibility** (\content-visibility: auto\) on \.history-msg\:
- Browser skips rendering off-screen messages entirely (similar to virtual scrolling)
- Dramatically reduces initial paint time for conversations with 100+ messages
- \contain-intrinsic-size: auto 80px\ provides scroll bar height estimation

**Impact:** Pure CSS, zero JS changes, no behavioral changes. These are performance hints that modern browsers (Chrome 85+, Firefox 125+, Safari 17.4+) use to optimize rendering. Older browsers simply ignore them.