### PR TITLE
fix: guard send() against offline state

### DIFF
--- a/app.js
+++ b/app.js
@@ -1028,6 +1028,10 @@ const ChatController = (() => {
    */
   async function send() {
     if (isSending) return;
+    if (typeof OfflineManager !== 'undefined' && OfflineManager.isOffline()) {
+      alert('You are offline. Messages cannot be sent without connectivity.');
+      return;
+    }
 
     const prompt = UIController.getChatInput();
 


### PR DESCRIPTION
Fixes #59

**Problem:** The Enter key handler calls `ChatController.send()` directly, bypassing the disabled Send button. The `send()` function had no offline check, so:
- The typed message was consumed and input cleared
- `fetch()` fired and failed with a generic error
- No connectivity guidance was shown
- Message content was lost

**Fix:** Added `OfflineManager.isOffline()` guard at the top of `send()`. This catches all entry points (keyboard, button, programmatic) and shows a clear offline message before any input is consumed.
