### PR TITLE
Wire SmartRetry into ChatController.send() — fix dead retry logic

### DIFF
--- a/app.js
+++ b/app.js
@@ -1084,24 +1084,30 @@ const ChatController = (() => {
       const sendStartTime = performance.now();
 
       if (ChatConfig.STREAMING_ENABLED) {
-        // Streaming path — show tokens as they arrive
+        // Streaming path — show tokens as they arrive, with automatic retry
         UIController.setChatOutput('');
-        const result = await callOpenAIStreaming(
-          ApiKeyManager.getOpenAIKey(),
-          ConversationManager.getMessages(),
-          (token) => UIController.appendChatOutput(token)
-        );
+        const result = await SmartRetry.withRetry(() => {
+          // Reset output on each retry attempt so partial streams don't accumulate
+          UIController.setChatOutput('');
+          return callOpenAIStreaming(
+            ApiKeyManager.getOpenAIKey(),
+            ConversationManager.getMessages(),
+            (token) => UIController.appendChatOutput(token)
+          );
+        });
 
         if (!result.ok) { _handleApiError(result); return; }
 
         reply = result.text || 'No response';
         usage = result.usage;
       } else {
-        // Non-streaming path — original behavior
+        // Non-streaming path — with automatic retry on transient failures
         UIController.setChatOutput('Thinking…');
-        const result = await callOpenAI(
-          ApiKeyManager.getOpenAIKey(),
-          ConversationManager.getMessages()
+        const result = await SmartRetry.withRetry(() =>
+          callOpenAI(
+            ApiKeyManager.getOpenAIKey(),
+            ConversationManager.getMessages()
+          )
         );
 
         if (!result.ok) { _handleApiError(result); return; }


### PR DESCRIPTION
## Summary

The SmartRetry module (~280 lines) provided complete automatic retry with exponential backoff, visual countdown, and cancel button — but was never actually called from ChatController.send(). Users got zero retry behavior on transient API failures.

## Changes

Wraps both API call paths in \SmartRetry.withRetry()\:

- **Streaming path**: resets \UIController.setChatOutput('')\ on each retry attempt to prevent partial stream accumulation from failed attempts
- **Non-streaming path**: straightforward wrap

Now users automatically get up to 3 retries with exponential backoff (1s, 2s, 4s + jitter) on 429/500/502/503 errors and network failures, with a visual countdown indicator and cancel button.

Fixes #64