### PR TITLE
fix: update stale model references in tests (gpt-3.5/gpt-4 → gpt-4.1)

### DIFF
--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -382,27 +382,27 @@ describe('UIController', () => {
   });
 
   test('showTokenUsage uses per-model pricing, not hardcoded gpt-4o rates', () => {
-    // gpt-3.5-turbo: $0.50/$1.50 per 1M tokens
-    ChatConfig.MODEL = 'gpt-3.5-turbo';
+    // gpt-4.1-nano: $0.10/$0.40 per 1M tokens
+    ChatConfig.MODEL = 'gpt-4.1-nano';
     UIController.showTokenUsage({
       prompt_tokens: 1000000,
       completion_tokens: 1000000,
       total_tokens: 2000000
     });
     var text = document.getElementById('token-usage').textContent;
-    // gpt-3.5-turbo cost: (1M * 0.50 + 1M * 1.50) / 1M = $2.0000
-    expect(text).toContain('$2.0000');
+    // gpt-4.1-nano cost: (1M * 0.10 + 1M * 0.40) / 1M = $0.5000
+    expect(text).toContain('$0.5000');
 
-    // gpt-4: $30/$60 per 1M tokens — most expensive model
-    ChatConfig.MODEL = 'gpt-4';
+    // gpt-4o: $2.50/$10.00 per 1M tokens
+    ChatConfig.MODEL = 'gpt-4o';
     UIController.showTokenUsage({
       prompt_tokens: 1000000,
       completion_tokens: 1000000,
       total_tokens: 2000000
     });
     text = document.getElementById('token-usage').textContent;
-    // gpt-4 cost: (1M * 30 + 1M * 60) / 1M = $90.0000
-    expect(text).toContain('$90.0000');
+    // gpt-4o cost: (1M * 2.50 + 1M * 10.00) / 1M = $12.5000
+    expect(text).toContain('$12.5000');
 
     // Reset
     ChatConfig.MODEL = 'gpt-4o';

--- a/tests/cost-dashboard.test.js
+++ b/tests/cost-dashboard.test.js
@@ -54,10 +54,10 @@ describe('CostDashboard', () => {
 
   test('recordUsage defaults model to ChatConfig.MODEL', () => {
     const originalModel = ChatConfig.MODEL;
-    ChatConfig.MODEL = 'gpt-3.5-turbo';
+    ChatConfig.MODEL = 'gpt-4.1-mini';
     CostDashboard.recordUsage({ prompt_tokens: 50, completion_tokens: 30 });
     const log = CostDashboard.getLog();
-    expect(log[0].model).toBe('gpt-3.5-turbo');
+    expect(log[0].model).toBe('gpt-4.1-mini');
     ChatConfig.MODEL = originalModel;
   });
 

--- a/tests/model-compare.test.js
+++ b/tests/model-compare.test.js
@@ -218,11 +218,11 @@ describe('ModelCompare', () => {
       const three = Object.assign({}, mockComparison, {
         responses: [
           ...mockComparison.responses,
-          { modelId: 'gpt-3.5-turbo', modelLabel: 'GPT-3.5', content: 'Four', latencyMs: 50, tokens: null, error: null }
+          { modelId: 'gpt-4.1-nano', modelLabel: 'GPT-4.1 Nano', content: 'Four', latencyMs: 50, tokens: null, error: null }
         ]
       });
       const html = ModelCompare.buildComparisonView(three);
-      expect(html).toContain('GPT-3.5');
+      expect(html).toContain('GPT-4.1 Nano');
       expect(html).toContain('Four');
       // Grid should have 3 columns
       expect(html).toContain('repeat(3,1fr)');

--- a/tests/modules.test.js
+++ b/tests/modules.test.js
@@ -614,18 +614,18 @@ describe('ModelSelector', () => {
     test('clicking a model updates ChatConfig.MODEL', () => {
       ModelSelector.toggle();
       const buttons = document.querySelectorAll('.model-option');
-      const gpt35btn = Array.from(buttons).find(b => b.title === 'gpt-3.5-turbo');
-      expect(gpt35btn).toBeDefined();
-      gpt35btn.click();
-      expect(ChatConfig.MODEL).toBe('gpt-3.5-turbo');
+      const miniBtn = Array.from(buttons).find(b => b.title === 'gpt-4.1-mini');
+      expect(miniBtn).toBeDefined();
+      miniBtn.click();
+      expect(ChatConfig.MODEL).toBe('gpt-4.1-mini');
     });
 
     test('clicking a model updates label', () => {
       ModelSelector.toggle();
       const buttons = document.querySelectorAll('.model-option');
-      const gpt4btn = Array.from(buttons).find(b => b.title === 'gpt-4');
-      gpt4btn.click();
-      expect(document.getElementById('model-label').textContent).toBe('GPT-4');
+      const gpt41btn = Array.from(buttons).find(b => b.title === 'gpt-4.1');
+      gpt41btn.click();
+      expect(document.getElementById('model-label').textContent).toBe('GPT-4.1');
     });
 
     test('clicking a model closes the panel', () => {


### PR DESCRIPTION
## Problem

Tests in modules.test.js, pp.test.js, cost-dashboard.test.js, and model-compare.test.js referenced removed models (gpt-3.5-turbo, gpt-4) that no longer exist in AVAILABLE_MODELS or MODEL_PRICING, causing test failures.

## Changes

- Updated model selector tests to use gpt-4.1-mini and gpt-4.1 instead of gpt-3.5-turbo and gpt-4
- Updated cost calculation tests with correct pricing for current models (gpt-4.1-nano: \.10/\.40, gpt-4o: \.50/\.00)
- Updated model compare test to use gpt-4.1-nano instead of gpt-3.5-turbo

## Impact

Fixes 3+ test suite failures caused by stale model references.