### PR TITLE
fix: sanitize localStorage data in ClipboardHistory and ConversationAgenda (CWE-1321)

### DIFF
--- a/app.js
+++ b/app.js
@@ -16601,7 +16601,7 @@ const ConversationAgenda = (() => {
   function _load() {
     try {
       const raw = SafeStorage.get(STORAGE_KEY);
-      agendas = raw ? JSON.parse(raw) : {};
+      agendas = raw ? sanitizeStorageObject(JSON.parse(raw)) : {};
     } catch (_) { agendas = {}; }
   }
 
@@ -16941,8 +16941,11 @@ const ClipboardHistory = (() => {
 
   function _load() {
     try {
-      const raw = localStorage.getItem(STORAGE_KEY);
-      if (raw) entries = JSON.parse(raw);
+      const raw = SafeStorage.get(STORAGE_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        entries = Array.isArray(parsed) ? sanitizeStorageObject(parsed) : [];
+      }
     } catch (_) {
       entries = [];
     }
@@ -16950,7 +16953,7 @@ const ClipboardHistory = (() => {
 
   function _save() {
     try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+      SafeStorage.set(STORAGE_KEY, JSON.stringify(entries));
     } catch (_) { /* quota exceeded — silently skip */ }
   }
 


### PR DESCRIPTION
**ClipboardHistory** bypassed SafeStorage and used raw \localStorage.getItem()\ + \JSON.parse()\ without \sanitizeStorageObject()\, exposing it to prototype pollution (CWE-1321).

**ConversationAgenda** used SafeStorage but didn't pass parsed data through \sanitizeStorageObject()\, leaving the same gap.

**Fixes:**
- ClipboardHistory: switch to SafeStorage + sanitizeStorageObject() + Array.isArray guard
- ConversationAgenda: add sanitizeStorageObject() to _load()
- Both now match the pattern used by SessionManager, Bookmarks, MessageReactions, and ModelCompare

7 insertions, 4 deletions.