### PR TITLE
feat: ChatGPT conversation importer — import conversations.json

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-/* ============================================================
+﻿﻿﻿/* ============================================================
  * Agentic Chat — Application Logic
  *
  * Architecture (45 modules, all revealing-module-pattern IIFEs):
@@ -60,6 +60,7 @@
  *   MessageFilter       — visual content-type filters (code/questions/links/errors/lists/role)
  *   ConversationSentiment — heuristic sentiment analysis with mood timeline (Ctrl+Shift+M)
  *   QuickSwitcher        — VS Code-style fuzzy session switcher (Ctrl+K)
+ *   ChatGPTImporter      — import ChatGPT exported conversations (conversations.json)
  *
  * All modules communicate through a thin public API; no direct DOM
  * manipulation outside UIController except where unavoidable (sandbox).
@@ -2916,6 +2917,8 @@ const SlashCommands = (() => {
             SessionManager.setSortMode(modes[next]);
             UIController.setChatOutput(`Sessions sorted: ${labels[next]}`);
           } },
+            { name: 'import-chatgpt', description: 'Import conversations from ChatGPT export (conversations.json)', icon: '🤖',
+          action: () => ChatGPTImporter.openFilePicker() },
     ]);
 
     function init() {
@@ -18404,3 +18407,163 @@ const WordCloud = (() => {
 })();
 
 document.addEventListener('DOMContentLoaded', WordCloud.init);
+
+
+/* ---------- ChatGPT Importer ---------- */
+/**
+ * Import ChatGPT exported conversations (conversations.json).
+ * ChatGPT exports a JSON array of conversations, each with a nested
+ * `mapping` tree of message nodes. This module parses that format,
+ * walks the tree to extract messages in order, and creates sessions
+ * via SessionManager.importSession().
+ *
+ * Supports both single-conversation and multi-conversation files.
+ * Triggered from a dedicated button in the History panel or via
+ * the /import-chatgpt slash command.
+ *
+ * @namespace ChatGPTImporter
+ */
+const ChatGPTImporter = (() => {
+  const MAX_CONVERSATIONS = 200;
+  const MAX_MESSAGES_PER = 500;
+
+  /**
+   * Parse a ChatGPT conversations.json structure.
+   * @param {string} jsonString - raw JSON text
+   * @returns {{ imported: number, skipped: number, names: string[] }}
+   */
+  function importFromJSON(jsonString) {
+    let data;
+    try {
+      data = JSON.parse(jsonString);
+    } catch (_) {
+      throw new Error('Invalid JSON file');
+    }
+
+    // Accept both array (full export) and single object
+    const conversations = Array.isArray(data) ? data : [data];
+    if (conversations.length === 0) throw new Error('No conversations found');
+
+    let imported = 0, skipped = 0;
+    const names = [];
+    const limit = Math.min(conversations.length, MAX_CONVERSATIONS);
+
+    for (let i = 0; i < limit; i++) {
+      const conv = conversations[i];
+      if (!conv || typeof conv !== 'object') { skipped++; continue; }
+
+      const messages = _extractMessages(conv);
+      if (messages.length === 0) { skipped++; continue; }
+
+      const title = typeof conv.title === 'string' && conv.title.trim()
+        ? conv.title.trim().substring(0, 200)
+        : 'ChatGPT Import';
+
+      // Build a session object compatible with SessionManager.importSession
+      const sessionJSON = JSON.stringify({
+        session: { name: title + ' (ChatGPT)', messages }
+      });
+
+      const result = SessionManager.importSession(sessionJSON);
+      if (result) {
+        imported++;
+        names.push(title);
+      } else {
+        skipped++;
+      }
+    }
+
+    return { imported, skipped, names };
+  }
+
+  /**
+   * Walk the ChatGPT mapping tree and extract messages in order.
+   * @param {object} conv - a single conversation object
+   * @returns {Array<{role: string, content: string}>}
+   */
+  function _extractMessages(conv) {
+    const mapping = conv.mapping;
+    if (!mapping || typeof mapping !== 'object') return [];
+
+    // Find root node (no parent)
+    let rootId = null;
+    for (const [id, node] of Object.entries(mapping)) {
+      if (!node.parent) { rootId = id; break; }
+    }
+    if (!rootId) return [];
+
+    // Walk the tree depth-first following children[0] (main branch)
+    const messages = [];
+    let currentId = rootId;
+    let safety = 0;
+
+    while (currentId && safety++ < 2000) {
+      const node = mapping[currentId];
+      if (!node) break;
+
+      if (node.message) {
+        const msg = node.message;
+        const role = msg.author && msg.author.role;
+        let content = '';
+
+        // ChatGPT stores content in parts array or as string
+        if (msg.content) {
+          if (Array.isArray(msg.content.parts)) {
+            content = msg.content.parts
+              .filter(p => typeof p === 'string')
+              .join('\n');
+          } else if (typeof msg.content === 'string') {
+            content = msg.content;
+          } else if (typeof msg.content.text === 'string') {
+            content = msg.content.text;
+          }
+        }
+
+        // Only keep user and assistant messages with actual content
+        if ((role === 'user' || role === 'assistant') && content.trim()) {
+          messages.push({ role, content: content.trim() });
+          if (messages.length >= MAX_MESSAGES_PER) break;
+        }
+      }
+
+      // Follow first child (main conversation branch)
+      const children = node.children;
+      currentId = Array.isArray(children) && children.length > 0
+        ? children[0] : null;
+    }
+
+    return messages;
+  }
+
+  /**
+   * Open a file picker for ChatGPT's conversations.json and import all.
+   */
+  function openFilePicker() {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.json';
+    input.addEventListener('change', () => {
+      const file = input.files[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = () => {
+        try {
+          const result = importFromJSON(reader.result);
+          const msg = result.imported > 0
+            ? `Imported ${result.imported} ChatGPT conversation${result.imported !== 1 ? 's' : ''}${result.skipped > 0 ? ` (${result.skipped} skipped)` : ''}.`
+            : 'No conversations could be imported. Make sure this is a ChatGPT export file.';
+          alert(msg);
+          if (result.imported > 0 && typeof HistoryPanel !== 'undefined') {
+            HistoryPanel.refresh();
+          }
+        } catch (e) {
+          alert('Import failed: ' + e.message);
+        }
+      };
+      reader.readAsText(file);
+    });
+    input.click();
+  }
+
+  return { importFromJSON, openFilePicker, _extractMessages };
+})();

--- a/index.html
+++ b/index.html
@@ -166,6 +166,7 @@
       <button id="sessions-new-btn" class="btn-sm" title="Start new session (Ctrl+N)">➕ New</button>
       <button id="sessions-save-btn" class="btn-sm" title="Save current session">💾 Save</button>
       <button id="sessions-import-btn" class="btn-sm" title="Import session from JSON">📥 Import</button>
+      <button id="sessions-import-chatgpt-btn" class="btn-sm" title="Import ChatGPT conversations.json" onclick="ChatGPTImporter.openFilePicker()">🤖 ChatGPT</button>
       <button id="sessions-tags-btn" class="btn-sm" title="Manage conversation tags">🏷️ Tags</button>
       <button id="sessions-merge-btn" class="btn-sm" title="Merge multiple sessions into one" onclick="ConversationMerge.open()">🔀 Merge</button>
       <button id="sessions-clear-btn" class="btn-sm btn-danger-sm" title="Delete all sessions">Clear All</button>

--- a/tests/ChatGPTImporter.test.js
+++ b/tests/ChatGPTImporter.test.js
@@ -1,0 +1,297 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// --- Minimal stubs for dependencies ---
+const SafeStorage = { get: () => null, set: () => {} };
+const SessionManager = {
+  importSession: jest.fn((jsonStr) => {
+    try {
+      const data = JSON.parse(jsonStr);
+      if (data.session && data.session.messages && data.session.messages.length > 0) {
+        return { id: 'test-id', name: data.session.name, messages: data.session.messages };
+      }
+    } catch (_) {}
+    return null;
+  })
+};
+const HistoryPanel = { refresh: jest.fn() };
+
+// Load the module — extract ChatGPTImporter IIFE from app.js and run it
+const fs = require('fs');
+const appCode = fs.readFileSync(require('path').join(__dirname, '..', 'app.js'), 'utf-8');
+const start = appCode.indexOf('const ChatGPTImporter = (() => {');
+const end = appCode.indexOf('})();', start) + 5;
+const moduleCode = appCode.substring(start, end);
+// Use Function constructor to execute in global-ish scope
+const fn = new Function('SessionManager', 'HistoryPanel', moduleCode + '\nreturn ChatGPTImporter;');
+const ChatGPTImporter = fn(SessionManager, HistoryPanel);
+
+describe('ChatGPTImporter', () => {
+  beforeEach(() => {
+    SessionManager.importSession.mockClear();
+    HistoryPanel.refresh.mockClear();
+  });
+
+  describe('_extractMessages', () => {
+    test('extracts user and assistant messages from mapping tree', () => {
+      const conv = {
+        mapping: {
+          'root': { parent: null, children: ['msg1'], message: null },
+          'msg1': { parent: 'root', children: ['msg2'], message: {
+            author: { role: 'user' },
+            content: { parts: ['Hello, how are you?'] }
+          }},
+          'msg2': { parent: 'msg1', children: [], message: {
+            author: { role: 'assistant' },
+            content: { parts: ['I am doing well, thanks!'] }
+          }}
+        }
+      };
+      const messages = ChatGPTImporter._extractMessages(conv);
+      expect(messages).toHaveLength(2);
+      expect(messages[0]).toEqual({ role: 'user', content: 'Hello, how are you?' });
+      expect(messages[1]).toEqual({ role: 'assistant', content: 'I am doing well, thanks!' });
+    });
+
+    test('skips system messages', () => {
+      const conv = {
+        mapping: {
+          'root': { parent: null, children: ['sys'], message: null },
+          'sys': { parent: 'root', children: ['msg1'], message: {
+            author: { role: 'system' },
+            content: { parts: ['You are a helpful assistant.'] }
+          }},
+          'msg1': { parent: 'sys', children: [], message: {
+            author: { role: 'user' },
+            content: { parts: ['Hi'] }
+          }}
+        }
+      };
+      const messages = ChatGPTImporter._extractMessages(conv);
+      expect(messages).toHaveLength(1);
+      expect(messages[0].role).toBe('user');
+    });
+
+    test('handles content as string (legacy format)', () => {
+      const conv = {
+        mapping: {
+          'root': { parent: null, children: ['msg1'], message: null },
+          'msg1': { parent: 'root', children: [], message: {
+            author: { role: 'user' },
+            content: 'Direct string content'
+          }}
+        }
+      };
+      const messages = ChatGPTImporter._extractMessages(conv);
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content).toBe('Direct string content');
+    });
+
+    test('handles content.text format', () => {
+      const conv = {
+        mapping: {
+          'root': { parent: null, children: ['msg1'], message: null },
+          'msg1': { parent: 'root', children: [], message: {
+            author: { role: 'assistant' },
+            content: { text: 'Text field content' }
+          }}
+        }
+      };
+      const messages = ChatGPTImporter._extractMessages(conv);
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content).toBe('Text field content');
+    });
+
+    test('joins multiple parts with newline', () => {
+      const conv = {
+        mapping: {
+          'root': { parent: null, children: ['msg1'], message: null },
+          'msg1': { parent: 'root', children: [], message: {
+            author: { role: 'user' },
+            content: { parts: ['Part 1', 'Part 2', 'Part 3'] }
+          }}
+        }
+      };
+      const messages = ChatGPTImporter._extractMessages(conv);
+      expect(messages[0].content).toBe('Part 1\nPart 2\nPart 3');
+    });
+
+    test('skips messages with empty content', () => {
+      const conv = {
+        mapping: {
+          'root': { parent: null, children: ['msg1'], message: null },
+          'msg1': { parent: 'root', children: ['msg2'], message: {
+            author: { role: 'user' },
+            content: { parts: ['  '] }
+          }},
+          'msg2': { parent: 'msg1', children: [], message: {
+            author: { role: 'assistant' },
+            content: { parts: ['Real response'] }
+          }}
+        }
+      };
+      const messages = ChatGPTImporter._extractMessages(conv);
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content).toBe('Real response');
+    });
+
+    test('returns empty array for missing mapping', () => {
+      expect(ChatGPTImporter._extractMessages({})).toEqual([]);
+      expect(ChatGPTImporter._extractMessages({ mapping: null })).toEqual([]);
+    });
+
+    test('filters non-string parts from content.parts', () => {
+      const conv = {
+        mapping: {
+          'root': { parent: null, children: ['msg1'], message: null },
+          'msg1': { parent: 'root', children: [], message: {
+            author: { role: 'user' },
+            content: { parts: ['Text', { type: 'image' }, 'More text'] }
+          }}
+        }
+      };
+      const messages = ChatGPTImporter._extractMessages(conv);
+      expect(messages[0].content).toBe('Text\nMore text');
+    });
+
+    test('follows first child in branching conversations', () => {
+      const conv = {
+        mapping: {
+          'root': { parent: null, children: ['a', 'b'], message: null },
+          'a': { parent: 'root', children: ['c'], message: {
+            author: { role: 'user' }, content: { parts: ['Branch A'] }
+          }},
+          'b': { parent: 'root', children: [], message: {
+            author: { role: 'user' }, content: { parts: ['Branch B'] }
+          }},
+          'c': { parent: 'a', children: [], message: {
+            author: { role: 'assistant' }, content: { parts: ['Reply to A'] }
+          }}
+        }
+      };
+      const messages = ChatGPTImporter._extractMessages(conv);
+      expect(messages).toHaveLength(2);
+      expect(messages[0].content).toBe('Branch A');
+      expect(messages[1].content).toBe('Reply to A');
+    });
+  });
+
+  describe('importFromJSON', () => {
+    test('imports array of conversations', () => {
+      const data = [
+        {
+          title: 'Chat 1',
+          mapping: {
+            'r': { parent: null, children: ['m1'], message: null },
+            'm1': { parent: 'r', children: [], message: {
+              author: { role: 'user' }, content: { parts: ['Hello'] }
+            }}
+          }
+        },
+        {
+          title: 'Chat 2',
+          mapping: {
+            'r': { parent: null, children: ['m1'], message: null },
+            'm1': { parent: 'r', children: [], message: {
+              author: { role: 'user' }, content: { parts: ['World'] }
+            }}
+          }
+        }
+      ];
+      const result = ChatGPTImporter.importFromJSON(JSON.stringify(data));
+      expect(result.imported).toBe(2);
+      expect(result.skipped).toBe(0);
+      expect(result.names).toEqual(['Chat 1', 'Chat 2']);
+      expect(SessionManager.importSession).toHaveBeenCalledTimes(2);
+    });
+
+    test('imports single conversation object', () => {
+      const data = {
+        title: 'Solo Chat',
+        mapping: {
+          'r': { parent: null, children: ['m1'], message: null },
+          'm1': { parent: 'r', children: [], message: {
+            author: { role: 'user' }, content: { parts: ['Hi'] }
+          }}
+        }
+      };
+      const result = ChatGPTImporter.importFromJSON(JSON.stringify(data));
+      expect(result.imported).toBe(1);
+      expect(result.names).toEqual(['Solo Chat']);
+    });
+
+    test('appends (ChatGPT) suffix to session name', () => {
+      const data = [{
+        title: 'My Chat',
+        mapping: {
+          'r': { parent: null, children: ['m1'], message: null },
+          'm1': { parent: 'r', children: [], message: {
+            author: { role: 'user' }, content: { parts: ['Hi'] }
+          }}
+        }
+      }];
+      ChatGPTImporter.importFromJSON(JSON.stringify(data));
+      const call = SessionManager.importSession.mock.calls[0][0];
+      const parsed = JSON.parse(call);
+      expect(parsed.session.name).toBe('My Chat (ChatGPT)');
+    });
+
+    test('uses fallback name for untitled conversations', () => {
+      const data = [{
+        mapping: {
+          'r': { parent: null, children: ['m1'], message: null },
+          'm1': { parent: 'r', children: [], message: {
+            author: { role: 'user' }, content: { parts: ['Hi'] }
+          }}
+        }
+      }];
+      ChatGPTImporter.importFromJSON(JSON.stringify(data));
+      const parsed = JSON.parse(SessionManager.importSession.mock.calls[0][0]);
+      expect(parsed.session.name).toBe('ChatGPT Import (ChatGPT)');
+    });
+
+    test('skips conversations with no valid messages', () => {
+      const data = [
+        { title: 'Empty', mapping: {} },
+        {
+          title: 'Has messages',
+          mapping: {
+            'r': { parent: null, children: ['m1'], message: null },
+            'm1': { parent: 'r', children: [], message: {
+              author: { role: 'user' }, content: { parts: ['Hi'] }
+            }}
+          }
+        }
+      ];
+      const result = ChatGPTImporter.importFromJSON(JSON.stringify(data));
+      expect(result.imported).toBe(1);
+      expect(result.skipped).toBe(1);
+    });
+
+    test('throws on invalid JSON', () => {
+      expect(() => ChatGPTImporter.importFromJSON('not json'))
+        .toThrow('Invalid JSON file');
+    });
+
+    test('throws on empty array', () => {
+      expect(() => ChatGPTImporter.importFromJSON('[]'))
+        .toThrow('No conversations found');
+    });
+
+    test('skips null entries in array', () => {
+      const data = [null, {
+        title: 'Valid',
+        mapping: {
+          'r': { parent: null, children: ['m1'], message: null },
+          'm1': { parent: 'r', children: [], message: {
+            author: { role: 'user' }, content: { parts: ['Hi'] }
+          }}
+        }
+      }];
+      const result = ChatGPTImporter.importFromJSON(JSON.stringify(data));
+      expect(result.imported).toBe(1);
+      expect(result.skipped).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## New Feature: ChatGPT Conversation Import

Import your ChatGPT conversation history into Agentic Chat. Parses the \conversations.json\ export format from ChatGPT Settings > Data Controls > Export.

### How it works
1. Click **🤖 ChatGPT** button in the Sessions toolbar, or use \/import-chatgpt\ slash command
2. Select your \conversations.json\ file
3. Conversations are imported as individual sessions with \(ChatGPT)\ suffix

### Technical details
- Walks ChatGPT's nested \mapping\ tree depth-first (follows first child = main conversation branch)
- Handles all content formats: \parts\ array, direct string, \	ext\ field
- Filters non-string parts (images, tool calls) — keeps only text
- Limits: 200 conversations max, 500 messages each (safety bounds)
- Creates sessions via existing \SessionManager.importSession()\

### Files changed
| File | Lines | Description |
|------|-------|-------------|
| \pp.js\ | +164 | ChatGPTImporter module + header comment + slash command |
| \index.html\ | +1 | 🤖 ChatGPT button in sessions toolbar |
| \	ests/ChatGPTImporter.test.js\ | +297 | **17 tests** (tree walking, content formats, branching, error handling) |

### Tests (17 total, all passing)
- \_extractMessages\: tree walking, system message filtering, 3 content formats, multi-part join, empty content skip, non-string part filtering, branch following
- \importFromJSON\: array import, single object, name suffixing, untitled fallback, empty conversation skipping, invalid JSON, empty array, null entries