### PR TITLE
perf: use single-pass regex in _escapeHtml

### DIFF
--- a/app.js
+++ b/app.js
@@ -235,8 +235,10 @@ function sanitizeStorageObject(obj) {
  * ConversationTimeline, and GlobalSessionSearch.
  */
 function _escapeHtml(str) {
-  return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  const s = String(str);
+  if (!/[&<>"']/.test(s)) return s; // fast path: no special chars
+  const map = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
+  return s.replace(/[&<>"']/g, c => map[c]);
 }
 
 /* ---------- Conversation Manager ---------- */


### PR DESCRIPTION
Replace five chained \.replace()\ calls with a single regex pass using a character map lookup. Adds a fast-path short-circuit when the string contains no special characters.

This function is called ~41 times across the codebase (via the \_esc\ alias) during UI rendering, so reducing regex passes from 5 to 1 (or 0 on the fast path) reduces GC pressure and CPU time, especially on large conversations.