### PR TITLE
security: restrict sandbox CSP connect-src to referenced domains

### DIFF
--- a/app.js
+++ b/app.js
@@ -393,6 +393,23 @@ const SandboxRunner = (() => {
    * If a previous sandbox is still running, it is cancelled first
    * to prevent promise/timer/listener leaks.
    */
+  /**
+   * Extract all HTTPS origins from code to build a restrictive connect-src CSP.
+   * This prevents sandboxed code from exfiltrating data (e.g. API keys) to
+   * arbitrary domains — only domains explicitly referenced in the code are allowed.
+   */
+  function _extractConnectOrigins(code) {
+    const originSet = new Set();
+    const re = /https:\/\/([a-zA-Z0-9._-]+)/g;
+    let m;
+    while ((m = re.exec(code)) !== null) {
+      originSet.add('https://' + m[1]);
+    }
+    return originSet.size > 0
+      ? Array.from(originSet).join(' ')
+      : "'none'";
+  }
+
   function run(code) {
     // Cancel any in-flight execution to prevent leaking the old
     // promise, its setTimeout, and its message-event listener.
@@ -401,9 +418,14 @@ const SandboxRunner = (() => {
     return new Promise((resolve) => {
       const nonce = crypto.randomUUID();
 
+      // Build a restrictive CSP: only allow connections to domains
+      // explicitly referenced in the code, preventing exfiltration
+      // of API keys or other sensitive data to attacker-controlled servers.
+      const connectSrc = _extractConnectOrigins(code);
+
       const iframeHTML = `<!DOCTYPE html><html><head>` +
         `<meta http-equiv="Content-Security-Policy" ` +
-        `content="default-src 'none'; script-src 'unsafe-inline'; connect-src https:;">` +
+        `content="default-src 'none'; script-src 'unsafe-inline'; connect-src ${connectSrc};">` +
         `</head><body><script>
         window.addEventListener('message', async function handler(evt) {
           if (!evt.data || evt.data.type !== 'sandbox-exec') return;


### PR DESCRIPTION
## Problem

The sandbox iframe used \connect-src https:\ in its Content Security Policy, allowing LLM-generated code to make network requests to **any** HTTPS endpoint. Combined with API key injection via \substituteServiceKey()\, a malicious LLM response could exfiltrate API keys to attacker-controlled servers.

## Fix

Dynamically build the CSP \connect-src\ directive from only the HTTPS origins explicitly referenced in the code being executed. This restricts network access to a whitelist derived from the code itself.

**Example:** Code calling \etch('https://api.openai.com/...')\ will only be allowed to connect to \https://api.openai.com\, not \https://evil.com\.

## Impact

- Prevents API key exfiltration through sandbox code
- Preserves legitimate API call functionality (referenced domains still work)
- No UX changes — transparent security hardening