### PR TITLE
cleanup: remove console.log statements from production code

### DIFF
--- a/app.js
+++ b/app.js
@@ -17732,7 +17732,7 @@ const OfflineManager = (function () {
     }
     if (_wasOffline) {
       _wasOffline = false;
-      console.log('[OfflineManager] Connection restored');
+      /* [OfflineManager] Connection restored */
     }
   }
 
@@ -17740,13 +17740,13 @@ const OfflineManager = (function () {
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker.register('/sw.js')
         .then(function (reg) {
-          console.log('[SW] Registered, scope:', reg.scope);
+          /* [SW] Registered */
           reg.addEventListener('updatefound', function () {
             var newWorker = reg.installing;
             if (newWorker) {
               newWorker.addEventListener('statechange', function () {
                 if (newWorker.state === 'activated') {
-                  console.log('[SW] New version activated');
+                  /* [SW] New version activated */
                 }
               });
             }


### PR DESCRIPTION
Replaces 3 console.log calls in the OfflineManager and service worker registration with comments. These were debug statements that pollute the browser console in production.