### PR TITLE
fix(security): prevent replace() \$-pattern injection in API key substitution

### DIFF
--- a/app.js
+++ b/app.js
@@ -604,7 +604,14 @@ const ApiKeyManager = (() => {
 
     const domain = extractDomain(code);
     if (serviceKeys[domain]) {
-      return code.replace(/YOUR_API_KEY/g, sanitizeKeyForCodeInjection(serviceKeys[domain]));
+      // Use a replacer function instead of a replacement string to prevent
+      // String.prototype.replace() from interpreting special $-patterns
+      // ($&, $`, $', $<name>) in the sanitized key.  Without this, a key
+      // containing e.g. "$&" would expand to the matched text "YOUR_API_KEY"
+      // in the output, corrupting the substitution and potentially leaking
+      // the placeholder into executable code.
+      const sanitized = sanitizeKeyForCodeInjection(serviceKeys[domain]);
+      return code.replace(/YOUR_API_KEY/g, () => sanitized);
     }
 
     // Show modal — store pending state
@@ -637,7 +644,8 @@ const ApiKeyManager = (() => {
   function submitServiceKey(key) {
     if (!key || !pendingDomain) return null;
     serviceKeys[pendingDomain] = key;
-    const code = pendingCode.replace(/YOUR_API_KEY/g, sanitizeKeyForCodeInjection(key));
+    const sanitized = sanitizeKeyForCodeInjection(key);
+    const code = pendingCode.replace(/YOUR_API_KEY/g, () => sanitized);
     pendingCode = pendingDomain = null;
     return code;
   }


### PR DESCRIPTION
## Problem

\String.prototype.replace()\ interprets special dollar-sign patterns (\\$&\, \\$'\, \\$\\) in the replacement string argument. In \substituteServiceKey()\ and \submitServiceKey()\, user-provided API keys are passed as replacement strings to \.replace(/YOUR_API_KEY/g, sanitized)\.

If a key contains sequences like \\$&\, the replace call would expand it to the matched text \YOUR_API_KEY\, corrupting the substituted code and potentially leaking the placeholder into executable JavaScript.

## Fix

Use a replacer function \() => sanitized\ instead of a plain replacement string. Replacer functions bypass all special-pattern interpretation, ensuring the sanitized key is inserted verbatim.

Affected functions: \ApiKeyManager.substituteServiceKey()\ and \ApiKeyManager.submitServiceKey()\.