### PR TITLE
docs: update README module catalog from 49 to 72 modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # 🤖 Agentic Chat
 
-**Turn natural language into executable code — right in your browser.**
+**Turn natural language into executable code - right in your browser.**
 
 [![Azure Static Web Apps CI/CD](https://github.com/sauravbhattacharya001/agenticchat/actions/workflows/azure-static-web-apps-gray-forest-0f6217910.yml/badge.svg)](https://github.com/sauravbhattacharya001/agenticchat/actions/workflows/azure-static-web-apps-gray-forest-0f6217910.yml)
 [![CodeQL](https://github.com/sauravbhattacharya001/agenticchat/actions/workflows/codeql.yml/badge.svg)](https://github.com/sauravbhattacharya001/agenticchat/actions/workflows/codeql.yml)
@@ -14,7 +14,7 @@
 [![GitHub last commit](https://img.shields.io/github/last-commit/sauravbhattacharya001/agenticchat)](https://github.com/sauravbhattacharya001/agenticchat/commits/main)
 [![codecov](https://codecov.io/gh/sauravbhattacharya001/agenticchat/graph/badge.svg)](https://codecov.io/gh/sauravbhattacharya001/agenticchat)
 
-A lightweight, zero-dependency chat interface that sends your prompts to GPT-4o, extracts the JavaScript it writes, and executes it in a sandboxed iframe — all from a single HTML file.
+A lightweight, zero-dependency chat interface that sends your prompts to GPT-4o, extracts the JavaScript it writes, and executes it in a sandboxed iframe - all from a single HTML file.
 
 [**Live Demo**](https://sauravbhattacharya001.github.io/agenticchat/) · [**Report Bug**](https://github.com/sauravbhattacharya001/agenticchat/issues) · [**Request Feature**](https://github.com/sauravbhattacharya001/agenticchat/issues)
 
@@ -25,69 +25,95 @@ A lightweight, zero-dependency chat interface that sends your prompts to GPT-4o,
 ## ✨ Features
 
 ### Core
-- **Natural Language → Code** — Ask a question or describe a task in plain English; GPT-4o returns JavaScript that gets executed automatically
-- **Sandboxed Execution** — Generated code runs in an `<iframe sandbox="allow-scripts">` with no access to the parent page's DOM, cookies, localStorage, or variables
-- **Content Security Policy** — The sandbox iframe enforces `default-src 'none'; connect-src https:` so code can call external APIs but nothing else
-- **Nonce Validation** — Each execution gets a `crypto.randomUUID()` nonce to prevent stale or replayed postMessage events
-- **Multi-Model Support** — Switch between GPT-4o, GPT-4o-mini, GPT-4-turbo, and more via the model selector
-- **API Key Management** — Detects `YOUR_API_KEY` placeholders in generated code and prompts for credentials per domain; keys are cached per session
+- **Natural Language → Code** - Ask a question or describe a task in plain English; GPT-4o returns JavaScript that gets executed automatically
+- **Sandboxed Execution** - Generated code runs in an `<iframe sandbox="allow-scripts">` with no access to the parent page's DOM, cookies, localStorage, or variables
+- **Content Security Policy** - The sandbox iframe enforces `default-src 'none'; connect-src https:` so code can call external APIs but nothing else
+- **Nonce Validation** - Each execution gets a `crypto.randomUUID()` nonce to prevent stale or replayed postMessage events
+- **Multi-Model Support** - Switch between GPT-4o, GPT-4o-mini, GPT-4-turbo, and more via the model selector
+- **API Key Management** - Detects `YOUR_API_KEY` placeholders in generated code and prompts for credentials per domain; keys are cached per session
 
 ### Conversation Management
-- **Conversation History** — Maintains a sliding window of up to 20 message pairs with automatic trimming and token-count warnings
-- **Multi-Session** — Create, switch between, rename, and delete multiple conversation sessions with auto-save
-- **Cross-Tab Sync** — Detects concurrent edits across browser tabs via BroadcastChannel
-- **Conversation Fork** — Branch conversations from any message into new sessions
-- **Chapters** — Insert named section dividers with a table-of-contents sidebar
-- **Tags** — Colored tag labels on sessions with filtering and management
-- **Auto-Tagger** — Heuristic topic detection and automatic tag suggestions
+- **Conversation History** - Maintains a sliding window of up to 20 message pairs with automatic trimming and token-count warnings
+- **Multi-Session** - Create, switch between, rename, and delete multiple conversation sessions with auto-save
+- **Cross-Tab Sync** - Detects concurrent edits across browser tabs via BroadcastChannel
+- **Conversation Fork** - Branch conversations from any message into new sessions
+- **Chapters** - Insert named section dividers with a table-of-contents sidebar
+- **Tags** - Colored tag labels on sessions with filtering and management
+- **Auto-Tagger** - Heuristic topic detection and automatic tag suggestions
 
 ### Search & Navigation
-- **Message Search** — Full-text search across conversation messages with highlighting
-- **Global Session Search** — Search across all saved sessions at once
-- **Conversation Timeline** — Visual minimap sidebar for conversation navigation
-- **Bookmarks & Pinning** — Bookmark messages for quick reference; pin important ones to a floating bar
-- **Slash Commands** — `/`-triggered command dropdown with autocomplete and keyboard navigation
+- **Message Search** - Full-text search across conversation messages with highlighting
+- **Global Session Search** - Search across all saved sessions at once
+- **Conversation Timeline** - Visual minimap sidebar for conversation navigation
+- **Bookmarks & Pinning** - Bookmark messages for quick reference; pin important ones to a floating bar
+- **Slash Commands** - `/`-triggered command dropdown with autocomplete and keyboard navigation
 
 ### Productivity
-- **Prompt Templates** — Built-in library of categorized prompt templates with search filtering
-- **Snippet Library** — Save, tag, search, rename, and re-run generated code snippets
-- **Quick Replies** — Contextual follow-up suggestion chips after AI responses
-- **Formatting Toolbar** — Markdown formatting buttons above the chat input
-- **Scratchpad** — Persistent notepad panel with copy/insert/download actions
-- **Input History** — Navigate previous prompts with ↑/↓ arrow keys
-- **File Drop Zone** — Drag-and-drop file inclusion (text-based files, 100 KB limit)
-- **Focus Mode** — Distraction-free zen mode (Ctrl+Shift+F)
+- **Prompt Templates** - Built-in library of categorized prompt templates with search filtering
+- **Snippet Library** - Save, tag, search, rename, and re-run generated code snippets
+- **Quick Replies** - Contextual follow-up suggestion chips after AI responses
+- **Formatting Toolbar** - Markdown formatting buttons above the chat input
+- **Scratchpad** - Persistent notepad panel with copy/insert/download actions
+- **Input History** - Navigate previous prompts with ↑/↓ arrow keys
+- **File Drop Zone** - Drag-and-drop file inclusion (text-based files, 100 KB limit)
+- **Focus Mode** - Distraction-free zen mode (Ctrl+Shift+F)
 
 ### Analysis & Insights
-- **Chat Stats** — Conversation analytics: word counts, code blocks, response timing
-- **Cost Dashboard** — Persistent API spend tracker with budget alerts and daily chart
-- **Message Diff** — Compare any two messages with visual line-level diff
-- **Conversation Summarizer** — Heuristic summary with topics, decisions, and action items
-- **Response Time Badge** — Per-response latency indicator
+- **Chat Stats** - Conversation analytics: word counts, code blocks, response timing
+- **Cost Dashboard** - Persistent API spend tracker with budget alerts and daily chart
+- **Message Diff** - Compare any two messages with visual line-level diff
+- **Conversation Summarizer** - Heuristic summary with topics, decisions, and action items
+- **Response Time Badge** - Per-response latency indicator
 
 ### Personalization
-- **Persona Presets** — Switchable system prompt presets with custom persona support
-- **Theme Manager** — Dark/light theme with OS preference detection
-- **Keyboard Shortcuts** — Global shortcuts with help modal
-- **Voice Input** — Browser speech recognition with language selection
-- **Read Aloud** — Text-to-speech for messages with voice/speed controls
+- **Persona Presets** - Switchable system prompt presets with custom persona support
+- **Theme Manager** - Dark/light theme with OS preference detection
+- **Keyboard Shortcuts** - Global shortcuts with help modal
+- **Voice Input** - Browser speech recognition with language selection
+- **Read Aloud** - Text-to-speech for messages with voice/speed controls
 
 ### Data
-- **Message Annotations** — Private notes/annotations on messages with labels
-- **Message Reactions** — Per-message emoji reactions with persistent counts
-- **Data Backup** — Full backup/restore for all 21 data keys (export/import/selective/merge)
-- **Zero Dependencies** — Single HTML file + CSS + JS. No build tools, no npm, no bundler. Just open and go.
-- **Input Guardrails** — Character limit (50K chars), token estimate warnings (~80K threshold), real-time counter
+- **Message Annotations** - Private notes/annotations on messages with labels
+- **Message Reactions** - Per-message emoji reactions with persistent counts
+- **Data Backup** - Full backup/restore for all 21 data keys (export/import/selective/merge)
+- **Zero Dependencies** - Single HTML file + CSS + JS. No build tools, no npm, no bundler. Just open and go.
+- **Input Guardrails** - Character limit (50K chars), token estimate warnings (~80K threshold), real-time counter
+
+### Productivity & Power User
+- **Command Palette** - VS Code-style universal command launcher (Ctrl+Shift+P) with fuzzy search
+- **Quick Switcher** - VS Code-style fuzzy session switcher (Ctrl+K)
+- **Smart Paste** - Intelligent paste formatting — auto-detects JSON, code, CSV, SQL, URLs, stack traces
+- **Smart Title** - AI-powered automatic session title generation
+- **Draft Recovery** - Auto-save/restore unsent message drafts per session
+- **Clipboard History** - Tracks copied text from chat with searchable panel (Ctrl+Shift+V)
+- **Typing Speed Monitor** - Live WPM indicator with sparkline dashboard (Ctrl+Shift+T)
+- **Message Context Menu** - Right-click context menu aggregating per-message actions
+- **Session Templates** - Save/load reusable session setups (persona, model, tags, starters)
+- **Session Notes** - Per-session notes/memos with inline editing
+
+### Learning & Analysis
+- **Conversation Flashcards** - Extract Q&A pairs as study flashcards with flip animation
+- **Conversation Sentiment** - Heuristic sentiment analysis with mood timeline (Ctrl+Shift+M)
+- **Conversation Health Check** - Diagnostic for prompt quality, balance, context usage, repetition
+- **Conversation Agenda** - Per-session goal checklist with progress tracking
+- **Message Filter** - Visual content-type filters (code/questions/links/errors/lists/role)
+- **Prompt A/B Tester** - Compare two model responses side-by-side with voting and history
+
+### Offline & Settings
+- **Offline Support** - Service worker for offline capability
+- **Preferences Panel** - Centralized settings panel with toggles, ranges, and reset
+- **ChatGPT Importer** - Import ChatGPT exported conversations (conversations.json)
+- **Focus Timer** - Pomodoro-style focus timer with work/break cycles (Alt+P)
 
 ### AI & Reliability
-- **Response Rating** — Thumbs up/down ratings on AI responses with model satisfaction dashboard
-- **Smart Retry** — Automatic retry with exponential backoff for transient API failures
-- **Message Editor** — Edit and resend user messages (truncates history and reloads into input)
-- **Message Translator** — Inline message translation to 20+ languages via OpenAI API
-- **Conversation Merge** — Combine 2+ sessions into one merged conversation with chronological interleaving
-- **Conversation Replay** — Message-by-message playback with transport controls (play/pause/speed)
-- **Prompt Library** — User-created prompt snippets with folders, search, usage tracking, import/export
-- **Usage Heatmap** — GitHub-style 7x24 activity heatmap across all sessions
+- **Response Rating** - Thumbs up/down ratings on AI responses with model satisfaction dashboard
+- **Smart Retry** - Automatic retry with exponential backoff for transient API failures
+- **Message Editor** - Edit and resend user messages (truncates history and reloads into input)
+- **Message Translator** - Inline message translation to 20+ languages via OpenAI API
+- **Conversation Merge** - Combine 2+ sessions into one merged conversation with chronological interleaving
+- **Conversation Replay** - Message-by-message playback with transport controls (play/pause/speed)
+- **Prompt Library** - User-created prompt snippets with folders, search, usage tracking, import/export
+- **Usage Heatmap** - GitHub-style 7x24 activity heatmap across all sessions
 
 ## 🚀 Getting Started
 
@@ -98,7 +124,7 @@ A lightweight, zero-dependency chat interface that sends your prompts to GPT-4o,
 
 ### Usage
 
-1. **Open** `index.html` in your browser — or visit the [live demo](https://sauravbhattacharya001.github.io/agenticchat/)
+1. **Open** `index.html` in your browser - or visit the [live demo](https://sauravbhattacharya001.github.io/agenticchat/)
 2. **Paste** your OpenAI API key into the key field (stored in memory only, never persisted)
 3. **Type** a question or task and press **Enter**
 4. **Watch** the generated code and its output appear in the console area
@@ -130,31 +156,32 @@ User Prompt  →  GPT-4o (system prompt: reply with JS only)
 ```
 
 1. A **system prompt** instructs GPT-4o to respond exclusively with JavaScript in a fenced code block
-2. The app **extracts** the code using regex and delivers it to a sandboxed iframe via `postMessage` (not template interpolation — preventing script-tag injection)
+2. The app **extracts** the code using regex and delivers it to a sandboxed iframe via `postMessage` (not template interpolation - preventing script-tag injection)
 3. The iframe **executes** the code with `new Function()` inside an async wrapper
 4. Results are **returned** via `postMessage` with origin validation (`'null'` for sandboxed iframes) and nonce matching
 
 ### Modules
 
-The codebase is organized into **49** IIFE modules in `app.js`, each using the revealing-module pattern:
+The codebase is organized into **72** IIFE modules in `app.js`, each using the revealing-module pattern:
 
 <details>
-<summary><strong>Core (7 modules)</strong></summary>
+<summary><strong>Core (8 modules)</strong></summary>
 
 | Module | Purpose |
 |--------|---------|
+| `DOMCache` | Lazy-caching wrapper around `getElementById` for high-frequency DOM lookups |
 | `SafeStorage` | Safe localStorage wrapper for restricted-storage environments |
-| `ChatConfig` | Frozen constants — model list, pricing, token limits, system prompt |
+| `ChatConfig` | Frozen constants - model list, pricing, token limits, system prompt |
 | `ConversationManager` | Message history with sliding window trimming and token estimation |
 | `SandboxRunner` | Iframe sandbox lifecycle, execution, timeout, cancellation |
 | `ApiKeyManager` | OpenAI + per-service key storage, substitution, validation |
-| `UIController` | All DOM manipulation — button states, modals, output |
+| `UIController` | All DOM manipulation - button states, modals, output |
 | `ChatController` | Orchestrates send flow: input → API → code extraction → sandbox |
 
 </details>
 
 <details>
-<summary><strong>Features (42 modules)</strong></summary>
+<summary><strong>Features (64 modules)</strong></summary>
 
 | Module | Purpose |
 |--------|---------|
@@ -201,7 +228,28 @@ The codebase is organized into **49** IIFE modules in `app.js`, each using the r
 | `MessageEditor` | Edit and resend user messages (truncate history + reload into input) |
 | `SmartRetry` | Automatic retry with exponential backoff for transient API failures |
 | `UsageHeatmap` | GitHub-style 7x24 activity heatmap across all sessions |
-| `SmartPaste` | Intelligent paste formatting — auto-detects JSON, code, CSV, SQL, URLs, stack traces |
+| `SmartPaste` | Intelligent paste formatting - auto-detects JSON, code, CSV, SQL, URLs, stack traces |
+| `SessionNotes` | Per-session notes/memos with inline editing |
+| `ConversationAgenda` | Per-session goal checklist with progress tracking |
+| `ClipboardHistory` | Tracks copied text from chat with searchable panel (Ctrl+Shift+V) |
+| `MessageFilter` | Visual content-type filters (code/questions/links/errors/lists/role) |
+| `ConversationSentiment` | Heuristic sentiment analysis with mood timeline (Ctrl+Shift+M) |
+| `QuickSwitcher` | VS Code-style fuzzy session switcher (Ctrl+K) |
+| `ChatGPTImporter` | Import ChatGPT exported conversations (conversations.json) |
+| `ConversationHealthCheck` | Heuristic conversation diagnostic (prompt quality, balance, context usage, repetition) |
+| `TypingSpeedMonitor` | Live WPM indicator with sparkline dashboard (Ctrl+Shift+T) |
+| `FocusTimer` | Pomodoro-style focus timer with work/break cycles (Alt+P) |
+| `CommandPalette` | VS Code-style universal command launcher (Ctrl+Shift+P) |
+| `DraftRecovery` | Auto-save/restore unsent message drafts per session |
+| `PreferencesPanel` | Centralized settings panel with toggles, ranges, and reset |
+| `SessionTemplates` | Save/load reusable session setups (persona, model, tags, starters) |
+| `ConversationFlashcards` | Extract Q&A pairs as study flashcards with flip animation |
+| `MessageContextMenu` | Right-click context menu aggregating per-message actions |
+| `PomodoroTimer` | Built-in focus timer with work/break cycles and stats |
+| `PromptABTester` | Compare two model responses side-by-side with voting and history |
+| `SmartTitle` | AI-powered automatic session title generation |
+| `ConversationSessions` | Multi-session state persistence and switching |
+| `OfflineManager` | Service worker registration and offline capability management |
 
 </details>
 
@@ -211,17 +259,17 @@ The app executes AI-generated code, so security is a first-class concern:
 
 | Layer | Protection |
 |-------|-----------|
-| **Iframe Sandbox** | `sandbox="allow-scripts"` — no DOM access, no cookies, no localStorage, no same-origin |
-| **CSP** | `default-src 'none'; connect-src https:` — only outbound HTTPS allowed |
+| **Iframe Sandbox** | `sandbox="allow-scripts"` - no DOM access, no cookies, no localStorage, no same-origin |
+| **CSP** | `default-src 'none'; connect-src https:` - only outbound HTTPS allowed |
 | **Origin Check** | postMessage validated against `'null'` origin (sandboxed iframe) |
 | **Nonce** | `crypto.randomUUID()` ties each execution to its result, preventing replay |
 | **Code Delivery** | Code sent via postMessage, not embedded in HTML (prevents `</script>` injection) |
-| **API Key Isolation** | OpenAI key stored in parent JS variable only — never exposed to sandbox |
+| **API Key Isolation** | OpenAI key stored in parent JS variable only - never exposed to sandbox |
 
 ### ⚠️ Known Limitations
 
-- **Outbound HTTPS is allowed** — The sandbox CSP includes `connect-src https:` so LLM-generated code can call external APIs. This is required for the core use case but means sandbox code can make network requests.
-- **Service API keys are injectable** — When you provide a third-party API key (e.g., weather API), it's injected into sandbox code. A prompt injection attack could theoretically exfiltrate it. Your OpenAI key is safe (parent page only).
+- **Outbound HTTPS is allowed** - The sandbox CSP includes `connect-src https:` so LLM-generated code can call external APIs. This is required for the core use case but means sandbox code can make network requests.
+- **Service API keys are injectable** - When you provide a third-party API key (e.g., weather API), it's injected into sandbox code. A prompt injection attack could theoretically exfiltrate it. Your OpenAI key is safe (parent page only).
 
 ## 🛠️ Tech Stack
 
@@ -239,7 +287,7 @@ The app executes AI-generated code, so security is a first-class concern:
 ```
 agenticchat/
 ├── index.html              # Single-page UI with CSP headers
-├── app.js                  # All application logic (48 modular IIFEs)
+├── app.js                  # All application logic (72 modular IIFEs)
 ├── style.css               # Responsive dark-theme styling
 ├── package.json            # npm metadata + test scripts
 ├── jest.config.js          # Jest test configuration
@@ -306,9 +354,9 @@ Contributions are welcome! Here's how:
 
 ### Guidelines
 
-- This is a **single-file app** — keep it that way unless there's a compelling reason to split
-- All 49 modules live in `app.js` as revealing-module IIFEs
-- Security is paramount — any change that touches the sandbox must be reviewed carefully
+- This is a **single-file app** - keep it that way unless there's a compelling reason to split
+- All 72 modules live in `app.js` as revealing-module IIFEs
+- Security is paramount - any change that touches the sandbox must be reviewed carefully
 - Test with various prompt types before submitting (simple questions, API calls, error cases)
 
 ## 📄 License

--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 /* ============================================================
  * Agentic Chat — Application Logic
  *
- * Architecture (46 modules, all revealing-module-pattern IIFEs):
+ * Architecture (72 modules, all revealing-module-pattern IIFEs):
  *
  *   Core:
  *   SafeStorage          — safe localStorage wrapper for restricted-storage environments


### PR DESCRIPTION
## Summary
The README and app.js header had inconsistent module counts (49, 48, 46) and were missing 22+ modules that have been added to the codebase.

### Changes
- Fixed module counts across README and app.js header to 72
- Added 22 missing modules to the Features documentation table
- Added new feature sections: Productivity & Power User, Learning & Analysis, Offline & Settings
- Updated project structure and contributing guidelines

### Modules Added
SessionNotes, ConversationAgenda, ClipboardHistory, MessageFilter, ConversationSentiment, QuickSwitcher, ChatGPTImporter, ConversationHealthCheck, TypingSpeedMonitor, FocusTimer, CommandPalette, DraftRecovery, PreferencesPanel, SessionTemplates, ConversationFlashcards, MessageContextMenu, PomodoroTimer, PromptABTester, SmartTitle, ConversationSessions, OfflineManager, DOMCache