### PR TITLE
security: restrict sandbox CSP connect-src to OpenAI API only

### DIFF
--- a/app.js
+++ b/app.js
@@ -493,7 +493,7 @@ const SandboxRunner = (() => {
 
       const iframeHTML = `<!DOCTYPE html><html><head>` +
         `<meta http-equiv="Content-Security-Policy" ` +
-        `content="default-src 'none'; script-src 'unsafe-inline'; connect-src https:;">` +
+        `content="default-src 'none'; script-src 'unsafe-inline'; connect-src https://api.openai.com;">` +
         `</head><body><script>
         window.addEventListener('message', async function handler(evt) {
           if (!evt.data || evt.data.type !== 'sandbox-exec') return;


### PR DESCRIPTION
The code sandbox iframe had \connect-src https:\ which allowed LLM-generated code running in the sandbox to make fetch requests to **any** HTTPS endpoint. If an API key was injected into the sandbox code (via the substituteServiceKey flow), malicious LLM output could exfiltrate the key to an attacker-controlled server.

Tightened to \connect-src https://api.openai.com\ since the sandbox is specifically designed for OpenAI API calls.

**Risk:** Medium — requires the LLM to produce malicious code that the user approves for execution, but the sandbox was supposed to be the safety net for exactly that scenario.