### PR TITLE
fix(security): prevent XSS via custom theme names in innerHTML

### DIFF
--- a/app.js
+++ b/app.js
@@ -22294,12 +22294,18 @@ const CustomThemeCreator = (() => {
     presetSelect.style.cssText = 'flex:1;min-width:100px;padding:4px 8px;background:var(--bg-primary);color:var(--text-primary);border:1px solid var(--border);border-radius:4px;font-size:12px;';
     presetSelect.innerHTML = '<option value="">- Apply Preset -</option>';
     Object.keys(PRESETS).forEach(name => {
-      presetSelect.innerHTML += `<option value="${name}">${name}</option>`;
+      const opt = document.createElement('option');
+      opt.value = name;
+      opt.textContent = name;
+      presetSelect.appendChild(opt);
     });
     // Add saved custom themes
     const customs = _loadCustomThemes();
     Object.keys(customs).forEach(name => {
-      presetSelect.innerHTML += `<option value="custom:${name}">★ ${name}</option>`;
+      const opt = document.createElement('option');
+      opt.value = 'custom:' + name;
+      opt.textContent = '★ ' + name;
+      presetSelect.appendChild(opt);
     });
     presetSelect.onchange = () => {
       const val = presetSelect.value;


### PR DESCRIPTION
## Summary

Custom theme names loaded from localStorage were injected directly into \innerHTML\ via template literals in the theme creator panel's preset dropdown. This allowed stored XSS if a malicious theme name containing HTML/script tags was present in localStorage (e.g. via a crafted import or direct storage manipulation).

## Changes

- Replaced \innerHTML +=\ concatenation with safe DOM API (\createElement\ + \	extContent\) for both built-in preset options and custom theme options.

## Impact

Prevents stored XSS attacks through crafted custom theme names. No functional changes — the dropdown renders identically.