### PR TITLE
fix(security): sanitize parsed JSON in ChatGPTImporter and importChapters

### DIFF
--- a/app.js
+++ b/app.js
@@ -10662,7 +10662,7 @@ const ConversationChapters = (() => {
 
   function importChapters(json) {
     try {
-      var arr = typeof json === 'string' ? JSON.parse(json) : json;
+      var arr = typeof json === 'string' ? sanitizeStorageObject(JSON.parse(json)) : json;
       if (!Array.isArray(arr)) return 0;
       var imported = 0;
       for (var j = 0; j < arr.length; j++) {
@@ -18802,7 +18802,7 @@ const ChatGPTImporter = (() => {
   function importFromJSON(jsonString) {
     let data;
     try {
-      data = JSON.parse(jsonString);
+      data = sanitizeStorageObject(JSON.parse(jsonString));
     } catch (_) {
       throw new Error('Invalid JSON file');
     }


### PR DESCRIPTION
## Problem

`ChatGPTImporter.importFromJSON` and `ConversationChapters.importChapters` parse untrusted external JSON via `JSON.parse()` without passing results through `sanitizeStorageObject()`. This leaves them vulnerable to **prototype pollution** attacks via dangerous keys in crafted import files.

## Fix

Route both parsers through the existing `sanitizeStorageObject()` helper, which strips dangerous keys. Every other import path in the codebase already does this — these two were missed.

## Changes
- `ChatGPTImporter.importFromJSON`: `JSON.parse()` → `sanitizeStorageObject(JSON.parse())`
- `ConversationChapters.importChapters`: same treatment for the string-input path
