### PR TITLE
fix: prevent stored XSS via custom theme names

### DIFF
--- a/app.js
+++ b/app.js
@@ -22295,12 +22295,18 @@ const CustomThemeCreator = (() => {
     presetSelect.style.cssText = 'flex:1;min-width:100px;padding:4px 8px;background:var(--bg-primary);color:var(--text-primary);border:1px solid var(--border);border-radius:4px;font-size:12px;';
     presetSelect.innerHTML = '<option value="">- Apply Preset -</option>';
     Object.keys(PRESETS).forEach(name => {
-      presetSelect.innerHTML += `<option value="${name}">${name}</option>`;
+      const opt = document.createElement('option');
+      opt.value = name;
+      opt.textContent = name;
+      presetSelect.appendChild(opt);
     });
     // Add saved custom themes
     const customs = _loadCustomThemes();
     Object.keys(customs).forEach(name => {
-      presetSelect.innerHTML += `<option value="custom:${name}">★ ${name}</option>`;
+      const opt = document.createElement('option');
+      opt.value = 'custom:' + name;
+      opt.textContent = '★ ' + name;
+      presetSelect.appendChild(opt);
     });
     presetSelect.onchange = () => {
       const val = presetSelect.value;


### PR DESCRIPTION
## Problem
Custom theme names entered via \prompt()\ were interpolated directly into \innerHTML\ when building the theme preset dropdown in CustomThemeCreator. A theme name like \<img src=x onerror=alert(1)>\ would execute arbitrary JavaScript every time the theme panel was opened.

## Fix
Replaced \innerHTML +=\ string interpolation with DOM API (\createElement\/\	extContent\/\ppendChild\) for user-supplied theme names, preventing HTML injection.

## Impact
Stored XSS — any code persisted in localStorage would execute on every panel open.