### PR TITLE
security: add client-side rate limiter to prevent API budget drain

### DIFF
--- a/app.js
+++ b/app.js
@@ -1180,12 +1180,36 @@ const ChatController = (() => {
    * On first call, captures the API key from the key input field.
    * Handles abort, timeout, and network errors with rollback.
    */
+  // ── Client-side rate limiter ──────────────────────────────────────
+  // Prevents runaway API spend from rapid-fire sends (spam-clicking,
+  // automated scripts, or malfunctioning retry loops).  Allows a burst
+  // of MAX_SENDS_PER_WINDOW requests within RATE_WINDOW_MS, then
+  // blocks until the oldest send falls outside the window.
+  const _sendTimestamps = [];
+  const RATE_WINDOW_MS = 60_000;   // 1 minute
+  const MAX_SENDS_PER_WINDOW = 20; // 20 requests/min — generous for human use
+
   async function send() {
     if (isSending) return;
     if (typeof OfflineManager !== 'undefined' && OfflineManager.isOffline()) {
       alert('You are offline. Messages cannot be sent without connectivity.');
       return;
     }
+
+    // Rate limiting: prune expired timestamps, then check
+    const now = Date.now();
+    while (_sendTimestamps.length > 0 && now - _sendTimestamps[0] > RATE_WINDOW_MS) {
+      _sendTimestamps.shift();
+    }
+    if (_sendTimestamps.length >= MAX_SENDS_PER_WINDOW) {
+      const waitSec = Math.ceil((RATE_WINDOW_MS - (now - _sendTimestamps[0])) / 1000);
+      alert(
+        `Rate limit reached (${MAX_SENDS_PER_WINDOW} messages/min). ` +
+        `Please wait ${waitSec}s before sending again.`
+      );
+      return;
+    }
+    _sendTimestamps.push(now);
 
     const prompt = UIController.getChatInput();
 


### PR DESCRIPTION
## Summary
Adds a sliding-window rate limiter (20 requests/minute) to \ChatController.send()\ to prevent runaway API spend.

## Problem
Currently, the only guard against rapid API calls is the \isSending\ flag, which prevents *concurrent* requests but doesn't limit *sequential* frequency. A user spam-clicking Send, or an automated script interacting with the page, could fire dozens of API calls per minute and drain their OpenAI API budget.

## Solution
A simple in-memory sliding window tracker (\_sendTimestamps\ array) that:
- Prunes timestamps older than 60 seconds on each send attempt
- Blocks sends when 20+ requests have been made in the current window
- Shows a user-friendly alert with seconds remaining until they can send again

The 20 req/min limit is generous for normal human interaction while catching automated abuse.

## Testing
- Manual: rapid-click Send button; after 20 sends in a minute, subsequent sends are blocked with an alert
- No existing tests broken (pre-existing failures in smart-retry.test.js are unrelated DOM issues)