### PR TITLE
perf: optimize GlobalSessionSearch to skip unnecessary sorting

### DIFF
--- a/app.js
+++ b/app.js
@@ -4115,6 +4115,15 @@ const SessionManager = (() => {
     if (isOpen) refresh();
   }
 
+  /**
+   * Return the raw cached sessions array without sorting or filtering.
+   * Used by search paths that don't need presentation order, avoiding
+   * the overhead of sort + localeCompare + pinned-set lookups.
+   */
+  function getAllUnsorted() {
+    return _loadAll().slice();
+  }
+
   function getAll() {
     const pinned = _getPinnedIds();
     const sortMode = _getSortMode();
@@ -4832,7 +4841,7 @@ const SessionManager = (() => {
   }
 
   return {
-    getAll, getCount, save, load, remove, rename, duplicate,
+    getAll, getAllUnsorted, getCount, save, load, remove, rename, duplicate,
     newSession, exportSession, importSession, clearAll,
     isAutoSaveEnabled, toggleAutoSave, autoSaveIfEnabled, initAutoSave,
     isPinned, togglePin, setSortMode, setSearchQuery,
@@ -11782,18 +11791,17 @@ const GlobalSessionSearch = (() => {
     const filterAssistant = DOMCache.get('gs-filter-assistant')?.checked ?? true;
     const caseSensitive = DOMCache.get('gs-filter-case')?.checked ?? false;
 
-    const sessions = SessionManager.getAll();
+    const sessions = SessionManager.getAllUnsorted();
     if (sessions.length === 0) {
-      _setStatus('No saved sessions to search');
-      return;
-    }
 
     const results = []; // { session, matches: [{ role, content, index }] }
     let totalMatches = 0;
+    const MAX_TOTAL_RESULTS = 100;
 
     const lowerQuery = caseSensitive ? query : query.toLowerCase();
 
     for (const session of sessions) {
+      if (totalMatches >= MAX_TOTAL_RESULTS) break;
       if (!session.messages || !Array.isArray(session.messages)) continue;
       const matches = [];
 
@@ -11816,6 +11824,7 @@ const GlobalSessionSearch = (() => {
       }
     }
 
+    const capped = totalMatches >= MAX_TOTAL_RESULTS;
     if (totalMatches === 0) {
       _setStatus(`No matches for "${query}"`);
       const container = DOMCache.get('global-search-results');
@@ -11828,7 +11837,7 @@ const GlobalSessionSearch = (() => {
       return;
     }
 
-    _setStatus(`${totalMatches} match${totalMatches !== 1 ? 'es' : ''} in ${results.length} session${results.length !== 1 ? 's' : ''}`);
+    _setStatus(`${totalMatches}${capped ? '+' : ''} match${totalMatches !== 1 ? 'es' : ''} in ${results.length} session${results.length !== 1 ? 's' : ''}${capped ? ' (showing first ' + MAX_TOTAL_RESULTS + ')' : ''}`);
     _renderResults(results, query, caseSensitive);
   }
 


### PR DESCRIPTION
## Summary

Optimizes the global session search (Ctrl+Shift+F) for users with many saved sessions.

### Changes

1. **Added \SessionManager.getAllUnsorted()\** — returns cached sessions without the overhead of sorting (O(n log n) with localeCompare), pinned-set lookups, and search filtering. Search only needs to iterate sessions, not present them in order.

2. **Use \getAllUnsorted()\ in GlobalSessionSearch** — eliminates sort overhead on every debounced keystroke (250ms).

3. **Added MAX_TOTAL_RESULTS cap (100)** with early termination — stops scanning sessions once 100 matches are found, preventing unnecessary iteration through all messages in all sessions. Shows a \100+ matches\ indicator when capped.

### Impact

For users with 30-50 sessions containing thousands of messages, this reduces per-keystroke search latency by eliminating the sort + full-scan overhead. The early termination is especially impactful for common/short search queries that match many messages.