### PR TITLE
security: restrict sandbox iframe connect-src to api.openai.com only

### DIFF
--- a/app.js
+++ b/app.js
@@ -591,7 +591,7 @@ const SandboxRunner = (() => {
 
       const iframeHTML = `<!DOCTYPE html><html><head>` +
         `<meta http-equiv="Content-Security-Policy" ` +
-        `content="default-src 'none'; script-src 'unsafe-inline'; connect-src https:; form-action 'none';">` +
+        `content="default-src 'none'; script-src 'unsafe-inline'; connect-src https://api.openai.com https://jsonplaceholder.typicode.com https://wttr.in; form-action 'none';">` +
         `</head><body><script>
         window.addEventListener('message', async function handler(evt) {
           if (!evt.data || evt.data.type !== 'sandbox-exec') return;


### PR DESCRIPTION
## Problem

The sandbox iframe CSP used \connect-src https:\ which allowed LLM-generated code running in the sandbox to make fetch/XHR requests to **any** HTTPS endpoint. This is a data exfiltration risk: untrusted code could send conversation history, API keys, or other sensitive data to an attacker-controlled server.

## Fix

Restrict \connect-src\ to only the domains the sandbox legitimately needs:
- \pi.openai.com\ — for API calls when user provides keys
- \jsonplaceholder.typicode.com\ — used by built-in prompt templates
- \wttr.in\ — used by the weather widget template

## Impact

Sandboxed code can no longer phone home to arbitrary servers. If users need additional domains for their use cases, they can extend the allowlist.