### PR TITLE
security: add Content-Security-Policy header and fix nginx header inheritance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://api.openai.com; img-src 'self' data: blob:; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'" always;
 
     # Gzip compression
     gzip on;
@@ -44,9 +45,17 @@ server {
     gzip_min_length 256;
 
     # Cache static assets
+    # Note: add_header in a location block inherits parent headers only
+    # when no add_header is used in the block. We must repeat security
+    # headers here to prevent them from being dropped.
     location ~* \.(css|js|ico|png|jpg|svg|woff2?)$ {
         expires 7d;
-        add_header Cache-Control "public, immutable";
+        add_header Cache-Control "public, immutable" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://api.openai.com; img-src 'self' data: blob:; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'" always;
     }
 
     # SPA fallback


### PR DESCRIPTION
## Changes

- **Add Content-Security-Policy header** to the nginx config in the Dockerfile, restricting:
  - \script-src\ to \'self' 'unsafe-inline'\ (app uses inline scripts)
  - \connect-src\ to \'self' https://api.openai.com\ (whitelist API endpoints)
  - \object-src 'none'\ — blocks Flash/Java embeds
  - \rame-ancestors 'self'\ — clickjacking protection (complements X-Frame-Options)
  - \ase-uri 'self'\ and \orm-action 'self'\ — prevents base tag hijacking and form redirection

- **Fix nginx header inheritance bug**: The static assets \location\ block used \dd_header Cache-Control\, which in nginx silently **drops all parent \dd_header\ directives** (X-Frame-Options, X-Content-Type-Options, etc.). Security headers were not being served on CSS, JS, images, or fonts. Fixed by repeating security headers in the location block.

- Add \lways\ flag to Cache-Control so it applies on error responses too.

## Why

Without CSP, the app is vulnerable to XSS payload execution even if input escaping is thorough — CSP is defense-in-depth. The header inheritance bug meant static assets had **zero** security headers in production.