### PR TITLE
Perf: debounce auto-save and use structuredClone

### DIFF
--- a/app.js
+++ b/app.js
@@ -3581,7 +3581,7 @@ const MessageReactions = (() => {
 
     function _getState() {
         return {
-            reactions: JSON.parse(JSON.stringify(reactions)),
+            reactions: structuredClone(reactions),
             availableEmojis: AVAILABLE_EMOJIS.slice()
         };
     }
@@ -4345,13 +4345,20 @@ const SessionManager = (() => {
   }
 
   /** Auto-save the current session (called after each message). */
+  let _autoSaveTimer = null;
   function autoSaveIfEnabled() {
     if (!autoSave) return;
-    const messages = ConversationManager.getUserMessages();
-    if (messages.length === 0) return;
+    // Debounce auto-save to avoid redundant localStorage writes when
+    // multiple messages arrive in quick succession (e.g. streaming).
+    if (_autoSaveTimer) clearTimeout(_autoSaveTimer);
+    _autoSaveTimer = setTimeout(() => {
+      _autoSaveTimer = null;
+      const messages = ConversationManager.getUserMessages();
+      if (messages.length === 0) return;
 
-    save();
-    if (isOpen) refresh();
+      save();
+      if (isOpen) refresh();
+    }, 500);
   }
 
   /** Generate a session name from conversation content using SmartTitle. */
@@ -4485,7 +4492,7 @@ const SessionManager = (() => {
     const copy = {
       id: crypto.randomUUID(),
       name: original.name + ' (copy)',
-      messages: JSON.parse(JSON.stringify(original.messages)),
+      messages: structuredClone(original.messages),
       messageCount: original.messageCount,
       preview: original.preview,
       createdAt: now,


### PR DESCRIPTION
## Changes

### 1. Debounced auto-save (500ms)
`autoSaveIfEnabled()` is called after every assistant response. Previously it wrote to localStorage synchronously each time. Now debounced with a 500ms delay — if another message arrives within that window, the timer resets and only one write happens.

### 2. Replace JSON.parse(JSON.stringify()) with structuredClone()
Two deep-clone sites used the JSON round-trip pattern:
- `MessageReactions._getState()` — cloning reactions map
- `SessionManager` duplicate — cloning session messages

`structuredClone()` is ~2-3x faster for complex objects, handles `undefined` values correctly, and is supported in all modern browsers (Chrome 98+, Firefox 94+, Safari 15.4+).
