### PR TITLE
perf: passive scroll/resize/mousemove listeners + rAF throttle scroll lock

### DIFF
--- a/app.js
+++ b/app.js
@@ -9075,9 +9075,9 @@ const ConversationTimeline = (() => {
     // Track scroll position
     const chatArea = getChatScrollParent();
     if (chatArea) {
-      chatArea.addEventListener('scroll', scheduleViewportUpdate);
+      chatArea.addEventListener('scroll', scheduleViewportUpdate, { passive: true });
     }
-    window.addEventListener('resize', scheduleViewportUpdate);
+    window.addEventListener('resize', scheduleViewportUpdate, { passive: true });
   }
 
   function buildDOM() {
@@ -9091,7 +9091,7 @@ const ConversationTimeline = (() => {
     stripEl = document.createElement('div');
     stripEl.id = 'timeline-strip';
     stripEl.addEventListener('click', handleStripClick);
-    stripEl.addEventListener('mousemove', handleStripHover);
+    stripEl.addEventListener('mousemove', handleStripHover, { passive: true });
     stripEl.addEventListener('mouseleave', hideTooltip);
 
     // Viewport indicator
@@ -25991,7 +25991,7 @@ const SmartScroll = (() => {
       }
       clearTimeout(_saveTick);
       _saveTick = setTimeout(savePosition, 1000);
-    });
+    }, { passive: true });
     window.addEventListener('beforeunload', savePosition);
 
     // End key shortcut
@@ -29183,15 +29183,21 @@ var ScrollLock = (function () {
     var el = _getChatOutput();
     if (!el) return;
 
+    var _scrollLockTick = false;
     el.addEventListener('scroll', function () {
-      if (_isNearBottom(el)) {
-        // User scrolled back to bottom → unlock
-        if (_locked) unlock();
-      } else {
-        // User scrolled up → lock
-        if (!_locked) lock();
-      }
-    });
+      if (_scrollLockTick) return;
+      _scrollLockTick = true;
+      requestAnimationFrame(function () {
+        _scrollLockTick = false;
+        if (_isNearBottom(el)) {
+          // User scrolled back to bottom → unlock
+          if (_locked) unlock();
+        } else {
+          // User scrolled up → lock
+          if (!_locked) lock();
+        }
+      });
+    }, { passive: true });
   }
 
   // Alt+J shortcut


### PR DESCRIPTION
## Summary

Adds \{ passive: true }\ to all scroll, resize, and mousemove event listeners that don't call \preventDefault()\. This allows the browser to start compositing immediately without waiting for JS handlers, eliminating scroll jank on lower-end devices.

Also adds \equestAnimationFrame\ throttling to the AutoScrollLock scroll handler, which was previously firing on every scroll event without debouncing.

### Changes

| Module | Event | Fix |
|--------|-------|-----|
| MiniMap | scroll | \{ passive: true }\ |
| MiniMap | resize | \{ passive: true }\ |
| MiniMap | mousemove (strip hover) | \{ passive: true }\ |
| ScrollMemory | scroll | \{ passive: true }\ |
| AutoScrollLock | scroll | \{ passive: true }\ + rAF throttle |

### Why this matters

Chrome DevTools flags non-passive scroll listeners as a performance issue. On mobile and lower-end devices, the browser blocks scrolling until the JS handler returns — even if it doesn't call \preventDefault()\. The \passive\ flag promises the browser that \preventDefault()\ won't be called, allowing scroll to proceed immediately.

The rAF throttle on AutoScrollLock prevents redundant DOM reads (\_isNearBottom\) during rapid scroll — batching them to once per animation frame instead of potentially dozens of times.