### PR TITLE
fix: replace O(n) shift() with circular buffer in rate limiter

### DIFF
--- a/app.js
+++ b/app.js
@@ -1728,6 +1728,7 @@ const ChatController = (() => {
   // of MAX_SENDS_PER_WINDOW requests within RATE_WINDOW_MS, then
   // blocks until the oldest send falls outside the window.
   const _sendTimestamps = [];
+  let _sendStart = 0;              // circular-buffer index into _sendTimestamps
   const RATE_WINDOW_MS = 60_000;   // 1 minute
   const MAX_SENDS_PER_WINDOW = 20; // 20 requests/min — generous for human use
 
@@ -1738,13 +1739,20 @@ const ChatController = (() => {
       return;
     }
 
-    // Rate limiting: prune expired timestamps, then check
+    // Rate limiting: advance start index past expired timestamps (O(1) amortized
+    // instead of O(n) Array.shift), then check active count.
     const now = Date.now();
-    while (_sendTimestamps.length > 0 && now - _sendTimestamps[0] > RATE_WINDOW_MS) {
-      _sendTimestamps.shift();
+    while (_sendStart < _sendTimestamps.length && now - _sendTimestamps[_sendStart] > RATE_WINDOW_MS) {
+      _sendStart++;
     }
-    if (_sendTimestamps.length >= MAX_SENDS_PER_WINDOW) {
-      const waitSec = Math.ceil((RATE_WINDOW_MS - (now - _sendTimestamps[0])) / 1000);
+    // Compact only when waste exceeds a threshold to bound memory
+    if (_sendStart > 100) {
+      _sendTimestamps.splice(0, _sendStart);
+      _sendStart = 0;
+    }
+    const _activeCount = _sendTimestamps.length - _sendStart;
+    if (_activeCount >= MAX_SENDS_PER_WINDOW) {
+      const waitSec = Math.ceil((RATE_WINDOW_MS - (now - _sendTimestamps[_sendStart])) / 1000);
       alert(
         `Rate limit reached (${MAX_SENDS_PER_WINDOW} messages/min). ` +
         `Please wait ${waitSec}s before sending again.`


### PR DESCRIPTION
Fixes #147.

## Changes

Replaces Array.shift() (O(n) per call) in the ChatController rate limiter with a start-index approach:

- Track _sendStart index instead of shifting the array
- Advance the index past expired timestamps (O(1) amortized)
- Compact only when waste exceeds 100 entries to bound memory
- Active count is _sendTimestamps.length - _sendStart

The common case (pruning 0-2 expired entries) goes from O(n) to O(1). The array no longer grows unbounded between rate-limit checks.